### PR TITLE
Add Objects/Operator folder (placeholder README)

### DIFF
--- a/Objects/Operator/README.md
+++ b/Objects/Operator/README.md
@@ -1,0 +1,5 @@
+# Operator
+
+Denne mappen er opprettet for å holde dokumentasjon for NeTEx-objektet "Operator".
+
+Foreløpig innhold er en plassholder. Strukturen vil følge malen fra Objects/DatedServiceJourney når dokumentasjonen fylles ut.


### PR DESCRIPTION
This PR adds a new folder: Objects/Operator/ with a minimal placeholder README.md. The folder is intended to host documentation for the NeTEx object "Operator" and will follow the structure used in Objects/DatedServiceJourney. Attribution: EnStandardBot (noted in commit message). No other content changes are included.