### PR TITLE
Add FramesOverview guide

### DIFF
--- a/Guides/FramesOverview.md
+++ b/Guides/FramesOverview.md
@@ -1,0 +1,18 @@
+# Frames Overview
+
+This guide provides an overview of the main NeTEx frames, their purpose, and links to detailed descriptions.
+
+## Key Frames
+
+- [ResourceFrame](../Frames/ResourceFrame/Description_ResourceFrame.md): Contains shared resources such as operators and organizations.
+- [ServiceFrame](../Frames/ServiceFrame/Description_ServiceFrame.md): Defines routes, lines, and scheduled stop points.
+- [TimetableFrame](../Frames/TimetableFrame/Description_TimetableFrame.md): Holds timetables and journey times.
+- [FareFrame](../Frames/FareFrame/Description_FareFrame.md): Describes fare structures and pricing information.
+- [SiteFrame](../Frames/SiteFrame/Description_SiteFrame.md): Represents physical locations such as stations and stops.
+- [VehicleScheduleFrame](../Frames/VehicleScheduleFrame/Description_VehicleScheduleFrame.md): Handles vehicle scheduling and blocks.
+- [ServiceCalendarFrame](../Frames/ServiceCalendarFrame/Description_ServiceCalendarFrame.md): Provides calendar information for services and operations.
+
+## Related Guides
+
+- [Get Started Guide](GetStarted_Guide.md)
+- [Main Guide](README.md)


### PR DESCRIPTION
This pull request adds a new guide `FramesOverview.md` under the Guides folder. The guide provides:

- An overview of the main NeTEx frames.
- Links to detailed description files for each frame.
- A short description for each frame.
- A section with related guides for easy navigation.