### PR TITLE
Align ServiceJourney Description with LLM template and add cross-references

### DIFF
--- a/Objects/ServiceJourney/Description_ServiceJourney.md
+++ b/Objects/ServiceJourney/Description_ServiceJourney.md
@@ -1,53 +1,51 @@
-# Description: ServiceJourney
+# ServiceJourney — Description
 
-This page describes the ServiceJourney object (planned trip) as used in the profile. It mirrors the structure and level of detail from the DatedServiceJourney description, but adapts the content to planned (non-dated) trips.
+Purpose
+- This document describes the ServiceJourney object in the profile and how it relates to adjacent objects. It follows the documentation structure defined in LLM/README.md and delegates attribute-level rules to the Attribute Table.
 
-Purpose: Provide a concise, operational overview of what a ServiceJourney is, how it connects to related objects, and which fields are central. Detailed field descriptions can be found in the ServiceJourney table.
+Scope
+- What is covered: conceptual description, key relationships, placement in the model, and references to authoritative tables and examples.
+- Out of scope: full attribute specification, cardinalities, and validation rules (see the Attribute Table).
 
-Related documents:
-- Table for ServiceJourney: Objects/ServiceJourney/Table_ServiceJourney.md
-- Dated instance of a trip: Objects/DatedServiceJourney/Description_DatedServiceJourney.md
+Authoritative attribute specification
+- See the Attribute Table for all fields, cardinality, constraints, and profile-specific rules:
+  - ./Table_ServiceJourney.md
 
-## What is a ServiceJourney?
-A ServiceJourney represents a planned trip in the timetable. It references a JourneyPattern to define the stop sequence, and it contains metadata such as operator, codes, and optional linkage to a block/roster. Planned stop times are expressed using passingTimes (TimetabledPassingTime) associated to StopPointInJourneyPattern entries. The dated variant (DatedServiceJourney) expresses the same trip for a specific operating day.
+Structure overview
+- ServiceJourney represents a scheduled vehicle journey running along a JourneyPattern that is associated with a Route and a Line. It is typically activated by DayType/ServiceCalendar conditions and may be grouped into operational Blocks. The Operator provides the service, and additional operational context can be attached via Notices and ServiceFacilitySets (profile dependent).
+- Key relationships:
+  - JourneyPattern → defines the ordered StopPoints and timing links that the ServiceJourney follows.
+  - Route and Line → provide routing and product/branding context for the ServiceJourney.
+  - DayType / ServiceCalendar → determine the days on which the ServiceJourney operates.
+  - Block → operational chaining of consecutive ServiceJourneys for vehicle/crew planning.
+  - Operator → the service provider responsible for operating the ServiceJourney.
+  - DatedServiceJourney → instantiates a ServiceJourney on a specific service date, including operational adjustments.
 
-## Key relationships
-- Line/Route: Associates the trip to a line/route via references.
-- JourneyPattern: Provides the stop sequence and structure used by the trip.
-- Operator: The operator performing the trip.
-- Block/VehicleJourneyGroup (if used): Optional linkage to a vehicle block/roster to ensure continuity between subsequent trips.
-- DayType/OperatingProfile: Specifies on which days the trip normally operates (per-date execution belongs to the dated instances and/or production rules).
+Key XML path overview (informative)
+- ServiceJourney located under:
+  - CompositeFrame / ServiceFrame / ServiceJourneys / ServiceJourney
+- Common references (profile-dependent, indicative only):
+  - ServiceJourney / JourneyPatternRef
+  - ServiceJourney / LineRef
+  - ServiceJourney / OperatorRef
+  - ServiceJourney / DayTypeRefs / DayTypeRef
+  - ServiceJourney / BlockRef
 
-## Central fields
-See the table Objects/ServiceJourney/Table_ServiceJourney.md for a complete list and cardinalities. Typical identifiers and references include:
-- id, version
-- privateCode/publicCode
-- journeyPatternRef (selected pattern)
-- lineRef/routeRef (owning line/route)
-- operatorRef
-- dayTypeRefs/operatingProfile (days of operation)
-- blockRef (optional roster linkage)
-- passingTimes (list of TimetabledPassingTime) with StopPointInJourneyPatternRef and ArrivalTime/DepartureTime
+Examples
+- Full examples are maintained as separate XML files:
+  - Minimal example: ./Example_ServiceJourney_MIN.xml
+  - Normal profile example: ./Example_ServiceJourney_NP.xml
+- Notes:
+  - XML examples are authoritative for illustrating correct linking and minimal vs. normal payloads, but attribute constraints remain defined by the Attribute Table.
 
-## Business rules (overview)
-- A ServiceJourney must reference exactly one valid JourneyPattern. The pattern's stop sequence is authoritative for the trip.
-- A ServiceJourney should belong to a single line/route; inconsistent cross-line references are not allowed.
-- If block/roster is used, trips in the same block must be time-compatible without overlap for the same vehicle.
-- DayType/OperatingProfile governs planned operation; per-date deviations are handled at the DatedServiceJourney level.
+Related documentation
+- Attribute table: ./Table_ServiceJourney.md
+- DatedServiceJourney — Description: ../DatedServiceJourney/Description_DatedServiceJourney.md
 
-## Comparison with DatedServiceJourney
-- ServiceJourney = template/plan for a trip without a concrete date.
-- DatedServiceJourney = concrete instance of a trip on a given date, with potential alterations (replacement, reinforcement, etc.).
-- Date-specific fields (e.g., ServiceAlteration on a specific day) belong to DatedServiceJourney, not ServiceJourney.
+References (informative)
+- NeTEx XSD (local copy):
+  - ../../XSD 2.0/xsd/netex_part_2/part2_journeyTimes/netex_serviceJourney_support.xsd
+  - ../../XSD 2.0/xsd/netex_part_2/part2_journeyTimes/netex_serviceJourney_version.xsd
 
-## Data quality and validation (recommendations)
-- Validate that journeyPatternRef, lineRef, and operatorRef exist and are consistent.
-- Ensure that DayType/OperatingProfile covers the expected timetable without conflicts.
-- Use privateCode/publicCode consistently for traceability and presentation.
-- Ensure passingTimes are present and aligned with the referenced StopPointInJourneyPattern sequence, using ArrivalTime and/or DepartureTime as appropriate.
-
-## Example
-See Objects/ServiceJourney/Example_ServiceJourney.xml for a minimal example including passingTimes.
-
-## Changelog
-- 2026-02-13: Initial version in English, adapted from the DatedServiceJourney template; added note on passingTimes.
+Change history
+- 2026-03-16: Aligned with repository documentation template. Added structure overview, relative links to table and related objects, example references, and informative XSD links.


### PR DESCRIPTION
This PR aligns Objects/ServiceJourney/Description_ServiceJourney.md with the repository documentation template and rules defined in LLM/README.md.

Key changes
- Add Purpose and Scope sections consistent with the template
- Add explicit relative cross-references:
  - ./Table_ServiceJourney.md
  - ../DatedServiceJourney/Description_DatedServiceJourney.md
  - Example files (./Example_ServiceJourney_MIN.xml and ./Example_ServiceJourney_NP.xml)
- Provide a structure overview describing key relationships (JourneyPattern, Route/Line, DayType/ServiceCalendar, Block, Operator, DatedServiceJourney)
- Include an informative XML path overview and local XSD references
- Add a change history entry

Notes
- No XML files were modified in this PR; examples referenced already exist in the repository.
- All changes comply with immutable directory rules (no changes to LLM/ or templates).