### PR TITLE
docs(ServiceJourney): rewrite Description to match Object_Description_Template

### DIFF
--- a/Objects/ServiceJourney/Description_ServiceJourney.md
+++ b/Objects/ServiceJourney/Description_ServiceJourney.md
@@ -1,53 +1,72 @@
-# Description: ServiceJourney
+# ServiceJourney
 
-This page describes the ServiceJourney object (planned trip) as used in the profile. It mirrors the structure and level of detail from the DatedServiceJourney description, but adapts the content to planned (non-dated) trips.
+Document status: Stable
+Object: ServiceJourney
+Profile scope: Timetable and journeys (NeTEx Part 2)
+File path: Objects/ServiceJourney/Description_ServiceJourney.md
+Related table: ./Table_ServiceJourney.md
+Related examples: ./Example_ServiceJourney_MIN.xml, ./Example_ServiceJourney_NP.xml
 
-Purpose: Provide a concise, operational overview of what a ServiceJourney is, how it connects to related objects, and which fields are central. Detailed field descriptions can be found in the ServiceJourney table.
+## Purpose
+This document describes the ServiceJourney object in the profile. A ServiceJourney represents a planned public‑transport vehicle journey that operates along a JourneyPattern with timing information at stops and references to related operational concepts.
 
-Related documents:
-- Table for ServiceJourney: Objects/ServiceJourney/Table_ServiceJourney.md
-- Dated instance of a trip: Objects/DatedServiceJourney/Description_DatedServiceJourney.md
+## Scope
+This description focuses on the conceptual and cross‑object semantics for ServiceJourney. Field‑level rules, cardinalities, and allowed values are specified in the attribute table (see Table_ServiceJourney.md). XML examples illustrate the minimum and a typical profile instance.
 
-## What is a ServiceJourney?
-A ServiceJourney represents a planned trip in the timetable. It references a JourneyPattern to define the stop sequence, and it contains metadata such as operator, codes, and optional linkage to a block/roster. Planned stop times are expressed using passingTimes (TimetabledPassingTime) associated to StopPointInJourneyPattern entries. The dated variant (DatedServiceJourney) expresses the same trip for a specific operating day.
+## Structure overview
+- Object: ServiceJourney
+- Key references: JourneyPatternRef, Calls/TimetabledPassingTimes, DayType/ServiceCalendar, Line/Route, Operator, optional Block
+- Realization on specific dates: DatedServiceJourney
+- Complementary specification: ./Table_ServiceJourney.md
 
-## Key relationships
-- Line/Route: Associates the trip to a line/route via references.
-- JourneyPattern: Provides the stop sequence and structure used by the trip.
-- Operator: The operator performing the trip.
-- Block/VehicleJourneyGroup (if used): Optional linkage to a vehicle block/roster to ensure continuity between subsequent trips.
-- DayType/OperatingProfile: Specifies on which days the trip normally operates (per-date execution belongs to the dated instances and/or production rules).
+## Relationships
+### JourneyPattern
+- ServiceJourney shall reference the JourneyPattern that defines the ordered sequence of ScheduledStopPoints used by this journey.
 
-## Central fields
-See the table Objects/ServiceJourney/Table_ServiceJourney.md for a complete list and cardinalities. Typical identifiers and references include:
-- id, version
-- privateCode/publicCode
-- journeyPatternRef (selected pattern)
-- lineRef/routeRef (owning line/route)
-- operatorRef
-- dayTypeRefs/operatingProfile (days of operation)
-- blockRef (optional roster linkage)
-- passingTimes (list of TimetabledPassingTime) with StopPointInJourneyPatternRef and ArrivalTime/DepartureTime
+### Calls and TimetabledPassingTimes
+- Calls associated with a ServiceJourney must be consistent with the JourneyPattern’s stop sequence.
+- TimetabledPassingTimes provide the timing at each call as required by the profile (arrival/departure and any runtime/layover rules).
 
-## Business rules (overview)
-- A ServiceJourney must reference exactly one valid JourneyPattern. The pattern's stop sequence is authoritative for the trip.
-- A ServiceJourney should belong to a single line/route; inconsistent cross-line references are not allowed.
-- If block/roster is used, trips in the same block must be time-compatible without overlap for the same vehicle.
-- DayType/OperatingProfile governs planned operation; per-date deviations are handled at the DatedServiceJourney level.
+### DayType / ServiceCalendar
+- Operating days are governed by DayType assignments and/or ServiceCalendar constructs according to the profile’s scheduling rules.
 
-## Comparison with DatedServiceJourney
-- ServiceJourney = template/plan for a trip without a concrete date.
-- DatedServiceJourney = concrete instance of a trip on a given date, with potential alterations (replacement, reinforcement, etc.).
-- Date-specific fields (e.g., ServiceAlteration on a specific day) belong to DatedServiceJourney, not ServiceJourney.
+### DatedServiceJourney
+- A DatedServiceJourney is the dated realization of a ServiceJourney.
+- See: ../DatedServiceJourney/Description_DatedServiceJourney.md
 
-## Data quality and validation (recommendations)
-- Validate that journeyPatternRef, lineRef, and operatorRef exist and are consistent.
-- Ensure that DayType/OperatingProfile covers the expected timetable without conflicts.
-- Use privateCode/publicCode consistently for traceability and presentation.
-- Ensure passingTimes are present and aligned with the referenced StopPointInJourneyPattern sequence, using ArrivalTime and/or DepartureTime as appropriate.
+### Line / Route / Operator
+- ServiceJourney may reference the producing Operator and be associated with a Line/Route in line with profile rules.
 
-## Example
-See Objects/ServiceJourney/Example_ServiceJourney.xml for a minimal example including passingTimes.
+### Blocks / Interlining (if applicable)
+- Where supported by the profile, ServiceJourney may participate in a Block to indicate vehicle workings across multiple journeys.
 
-## Changelog
-- 2026-02-13: Initial version in English, adapted from the DatedServiceJourney template; added note on passingTimes.
+## Key constraints (profile)
+- Identification/versioning must follow repository conventions for IDs and version attributes.
+- JourneyPatternRef is required and defines the stop sequence for the journey.
+- The set of Calls/TimetabledPassingTimes must align 1‑to‑1 with the JourneyPattern’s ScheduledStopPoints and order.
+- Timing rules must comply with the profile (arrival/departure presence, run/layover handling, after‑midnight times).
+- Operating days must be expressed through DayType/ServiceCalendar as profiled.
+- References to Line, Route, and Operator shall be provided when mandated by the profile context.
+
+## Examples
+- Minimal example
+  - File: ./Example_ServiceJourney_MIN.xml
+  - Demonstrates only mandatory elements and references for a valid ServiceJourney in this profile.
+- Normal profile example
+  - File: ./Example_ServiceJourney_NP.xml
+  - Demonstrates common optional fields and typical cross‑references beyond the minimum.
+
+## Cross‑references
+- Attribute table: ./Table_ServiceJourney.md
+- Dated realization: ../DatedServiceJourney/Description_DatedServiceJourney.md
+
+## Paths and linking rules
+- All links in this document are relative to its file path.
+- Cross‑object links use consistent, relative paths per repository documentation rules.
+
+## XSD and standard references
+- NeTEx Part 2 (timetable and journey definitions) is the normative standard context.
+- The repository tracks NeTEx 2.0 schemas in the XSD directory.
+
+## Change history
+- 2026‑03‑16: Rewritten to align with Object_Description_Template (sections, relative links, constraints) and repository documentation rules.


### PR DESCRIPTION
This PR rewrites Objects/ServiceJourney/Description_ServiceJourney.md to strictly follow Object_Description_Template.md.

Conformance to template
- Added mandatory header block (document status, object name, scope, file path, related resources).
- Structured sections exactly as in the template: Purpose, Scope, Structure overview, Relationships (subsections), Key constraints (profile), Examples, Cross-references, Paths and linking rules, XSD/standard references, Change history.
- Ensured all internal links are relative and align with repository rules.

Cross-links
- ./Table_ServiceJourney.md
- ./Example_ServiceJourney_MIN.xml
- ./Example_ServiceJourney_NP.xml
- ../DatedServiceJourney/Description_DatedServiceJourney.md

Compliance notes
- No XML files modified.
- LLM/* directories untouched.
- One file changed in a single commit on a dedicated temporary feature branch.

After merge
- Do not reuse branch feat/ServiceJourney/2026-03-16-2217.