### PR TITLE
docs(ServiceJourney): Align Description_ServiceJourney.md with Object_Description_Template

### DIFF
--- a/Objects/ServiceJourney/Description_ServiceJourney.md
+++ b/Objects/ServiceJourney/Description_ServiceJourney.md
@@ -1,53 +1,43 @@
-# Description: ServiceJourney
+# ServiceJourney
 
-This page describes the ServiceJourney object (planned trip) as used in the profile. It mirrors the structure and level of detail from the DatedServiceJourney description, but adapts the content to planned (non-dated) trips.
+> Authoritative description for the ServiceJourney object in this profile. This page follows the Object_Description_Template and provides a concise, task‑oriented description with cross‑references to structure, tables, and validated XML examples.
 
-Purpose: Provide a concise, operational overview of what a ServiceJourney is, how it connects to related objects, and which fields are central. Detailed field descriptions can be found in the ServiceJourney table.
+## Purpose
+A ServiceJourney represents a planned public transport vehicle journey that performs passenger services along a JourneyPattern on a specific Line. It defines the stop visits and timing, and references operational context such as DayType, Operator and ResponsibilitySet where applicable.
 
-Related documents:
-- Table for ServiceJourney: Objects/ServiceJourney/Table_ServiceJourney.md
-- Dated instance of a trip: Objects/DatedServiceJourney/Description_DatedServiceJourney.md
+## When to use
+Use ServiceJourney to describe a customer‑facing journey that can be offered in timetables and journey planning. It should be used together with JourneyPattern, Route, Line and related operational objects to form a coherent, schedulable service.
 
-## What is a ServiceJourney?
-A ServiceJourney represents a planned trip in the timetable. It references a JourneyPattern to define the stop sequence, and it contains metadata such as operator, codes, and optional linkage to a block/roster. Planned stop times are expressed using passingTimes (TimetabledPassingTime) associated to StopPointInJourneyPattern entries. The dated variant (DatedServiceJourney) expresses the same trip for a specific operating day.
+## Core characteristics
+- Identifies the journey by id and version.
+- References Line, JourneyPattern, Operator and other context objects as needed.
+- Contains ServiceJourneyPatternTiming elements through stop assignments and run times according to the profile.
+- Can be associated with DayType/OperatingPeriod via DatedServiceJourney or validity constructs, depending on publication scope.
 
-## Key relationships
-- Line/Route: Associates the trip to a line/route via references.
-- JourneyPattern: Provides the stop sequence and structure used by the trip.
-- Operator: The operator performing the trip.
-- Block/VehicleJourneyGroup (if used): Optional linkage to a vehicle block/roster to ensure continuity between subsequent trips.
-- DayType/OperatingProfile: Specifies on which days the trip normally operates (per-date execution belongs to the dated instances and/or production rules).
+## Profile rules and constraints
+This profile may restrict which elements are mandatory and how references are formed. Refer to the structure and table overview for the normative list of elements, cardinalities, allowed values and cross‑object references.
 
-## Central fields
-See the table Objects/ServiceJourney/Table_ServiceJourney.md for a complete list and cardinalities. Typical identifiers and references include:
-- id, version
-- privateCode/publicCode
-- journeyPatternRef (selected pattern)
-- lineRef/routeRef (owning line/route)
-- operatorRef
-- dayTypeRefs/operatingProfile (days of operation)
-- blockRef (optional roster linkage)
-- passingTimes (list of TimetabledPassingTime) with StopPointInJourneyPatternRef and ArrivalTime/DepartureTime
+- Structure and attribute table: ./Table_ServiceJourney.md
 
-## Business rules (overview)
-- A ServiceJourney must reference exactly one valid JourneyPattern. The pattern's stop sequence is authoritative for the trip.
-- A ServiceJourney should belong to a single line/route; inconsistent cross-line references are not allowed.
-- If block/roster is used, trips in the same block must be time-compatible without overlap for the same vehicle.
-- DayType/OperatingProfile governs planned operation; per-date deviations are handled at the DatedServiceJourney level.
+## Examples
+The following example files illustrate minimal and normal profile (NP) variants. They are maintained with this object and are expected to be valid against NeTEx 2.0 as published in this repository.
 
-## Comparison with DatedServiceJourney
-- ServiceJourney = template/plan for a trip without a concrete date.
-- DatedServiceJourney = concrete instance of a trip on a given date, with potential alterations (replacement, reinforcement, etc.).
-- Date-specific fields (e.g., ServiceAlteration on a specific day) belong to DatedServiceJourney, not ServiceJourney.
+- Minimal profile example: ./Example_ServiceJourney_MIN.xml
+- Normal profile example: ./Example_ServiceJourney_NP.xml
 
-## Data quality and validation (recommendations)
-- Validate that journeyPatternRef, lineRef, and operatorRef exist and are consistent.
-- Ensure that DayType/OperatingProfile covers the expected timetable without conflicts.
-- Use privateCode/publicCode consistently for traceability and presentation.
-- Ensure passingTimes are present and aligned with the referenced StopPointInJourneyPattern sequence, using ArrivalTime and/or DepartureTime as appropriate.
+## Related objects
+For complete context and referential integrity, see the descriptions and tables for the objects commonly referenced by ServiceJourney:
+- Line (object description and table)
+- JourneyPattern (object description and table)
+- DatedServiceJourney (object description and table)
+- DayType (object description and table)
 
-## Example
-See Objects/ServiceJourney/Example_ServiceJourney.xml for a minimal example including passingTimes.
+Note: Use relative links following the profile’s linking rules when navigating between these objects.
 
-## Changelog
-- 2026-02-13: Initial version in English, adapted from the DatedServiceJourney template; added note on passingTimes.
+## Notes and guidance
+- Ensure identifiers are unique and follow the repository codespace rules.
+- Keep ServiceJourney focused on passenger‑carrying operations; use other objects for operational coupling, block working and non‑passenger movements.
+- Validate any new or modified XML examples before committing (the existing examples are assumed validated).
+
+## Change log
+- Aligned content, sections and cross‑references with Object_Description_Template; clarified purpose, usage and references; added explicit links to structure table and examples.


### PR DESCRIPTION
Summary
- Aligns Objects/ServiceJourney/Description_ServiceJourney.md with LLM/Templates/Object_Description_Template.md.
- Keeps documentation in English per LLM/README.md.
- Adds clear Purpose, When to use, Core characteristics, Profile rules and constraints, Examples, Related objects, Notes and guidance, and Change log sections.
- Cross-references the structure table (./Table_ServiceJourney.md) and existing validated examples (./Example_ServiceJourney_MIN.xml and ./Example_ServiceJourney_NP.xml) using relative links.

Scope and compliance
- Changed files: 1 (Description_ServiceJourney.md only), in one commit.
- No XML files were created or modified in this PR; therefore, NeTEx validation step was not required.
- Branch name follows feat/<ObjectName>/<YYYY-MM-DD-HHMM> and is based on EnStandardBranch.
- Follows documentation rules and templates defined in LLM/README.md.

Notes
- Related object links are referenced textually; further relative links can be added in future PRs if desired, following the linking rules in LLM/README.md.