### PR TITLE
docs: Add Frame templates and standardize all Frame documentation

### DIFF
--- a/Frames/FareFrame/Description_FareFrame.md
+++ b/Frames/FareFrame/Description_FareFrame.md
@@ -4,7 +4,30 @@
 
 A **FareFrame** contains fare data, products, and pricing rules for a public transport delivery. It groups Tariffs, ValidableElements, PreassignedFareProducts, and SalesOfferPackages — the elements that define what passengers can buy and at what price.
 
-## 2. Contained Elements
+## 2. Structure Overview
+
+```text
+📄 @id (1..1)
+📄 @version (1..1)
+📁 tariffs (0..1)
+   └── 📄 Tariff (0..n)
+📁 validableElements (0..1)
+   └── 📄 ValidableElement (0..n)
+📁 fareProducts (0..1)
+   └── 📄 PreassignedFareProduct (0..n)
+       ├── 📁 accessRightsInProduct (0..1)
+       │   └── 📄 AccessRightInProduct (0..n)
+       │       └── 🔗 ValidableElementRef/@ref (1..1)
+       └── 📁 tariffs (0..1)
+           └── 🔗 TariffRef/@ref (0..n)
+📁 salesOfferPackages (0..1)
+   └── 📄 SalesOfferPackage (0..n)
+       └── 📁 salesOfferPackageElements (0..1)
+           └── 📄 SalesOfferPackageElement (0..n)
+               └── 🔗 PreassignedFareProductRef/@ref (1..1)
+```
+
+## 3. Contained Elements
 
 - **tariffs** – Collection of Tariff definitions describing fare structures and pricing rules
 - **validableElements** – Collection of ValidableElement definitions representing travel rights that can be validated
@@ -12,7 +35,7 @@ A **FareFrame** contains fare data, products, and pricing rules for a public tra
   - PreassignedFareProduct – A pre-defined fare product (e.g., single ticket) with access rights and tariff references
 - **salesOfferPackages** – Collection of SalesOfferPackage definitions bundling fare products for sale
 
-## 3. Frame Relationships
+## 4. Frame Relationships
 
 FareFrame depends on **ResourceFrame** for organisational context. It may reference [TariffZone](../../Objects/TariffZone/Table_TariffZone.md) definitions. **SalesTransactionFrame** references fare products and sales offer packages defined here. FareFrame is typically wrapped in a **CompositeFrame** within a PublicationDelivery.
 

--- a/Frames/FareFrame/Description_FareFrame.md
+++ b/Frames/FareFrame/Description_FareFrame.md
@@ -1,21 +1,20 @@
-# FareFrame – description
+# FareFrame
 
-**Purpose:** Fare data, products, and pricing rules.
+## 1. Purpose
 
-**Typical elements:** FareStructureElements, FareProducts, Tariffs, SalesOfferPackages, Prices.
+A **FareFrame** contains fare data, products, and pricing rules for a public transport delivery. It groups Tariffs, ValidableElements, PreassignedFareProducts, and SalesOfferPackages — the elements that define what passengers can buy and at what price.
 
-**Keys:** id, version, tariffRef/fareProductRef/fareStructureElementRef.
+## 2. Contained Elements
 
-**Example:**
-```xml
-<netex:FareFrame id="NO:FareFrame:1" version="1">
-  <netex:fareProducts>
-    <netex:PreassignedFareProduct id="NO:FP:single" version="1" name="Enkeltbillett"/>
-  </netex:fareProducts>
-  <netex:tariffs>
-    <netex:Tariff id="NO:Tariff:zone" version="1"/>
-  </netex:tariffs>
-</netex:FareFrame>
-```
+- **tariffs** – Collection of Tariff definitions describing fare structures and pricing rules
+- **validableElements** – Collection of ValidableElement definitions representing travel rights that can be validated
+- **fareProducts** – Collection of fare product types:
+  - PreassignedFareProduct – A pre-defined fare product (e.g., single ticket) with access rights and tariff references
+- **salesOfferPackages** – Collection of SalesOfferPackage definitions bundling fare products for sale
 
-**XSD:** See FareFrame in NeTEx.
+## 3. Frame Relationships
+
+FareFrame depends on **ResourceFrame** for organisational context. It may reference [TariffZone](../../Objects/TariffZone/Table_TariffZone.md) definitions. **SalesTransactionFrame** references fare products and sales offer packages defined here. FareFrame is typically wrapped in a **CompositeFrame** within a PublicationDelivery.
+
+For the full structural specification, see [Table — FareFrame](Table_FareFrame.md).
+Example XML: [Example_FareFrame.xml](Example_FareFrame.xml)

--- a/Frames/FareFrame/Table_FareFrame.md
+++ b/Frames/FareFrame/Table_FareFrame.md
@@ -1,0 +1,58 @@
+# FareFrame
+
+## Structure Overview
+
+```text
+FareFrame
+ ├─ @id (1..1)
+ ├─ @version (1..1)
+ ├─ tariffs (0..1)
+ │   └─ Tariff (0..n)
+ │       └─ Name (0..1)
+ ├─ validableElements (0..1)
+ │   └─ ValidableElement (0..n)
+ │       └─ Name (0..1)
+ ├─ fareProducts (0..1)
+ │   └─ PreassignedFareProduct (0..n)
+ │       ├─ Name (0..1)
+ │       ├─ accessRightsInProduct (0..1)
+ │       │   └─ AccessRightInProduct (0..n)
+ │       │       └─ ValidableElementRef/@ref (1..1)
+ │       └─ tariffs (0..1)
+ │           └─ TariffRef/@ref (0..n)
+ └─ salesOfferPackages (0..1)
+     └─ SalesOfferPackage (0..n)
+         ├─ Name (0..1)
+         └─ salesOfferPackageElements (0..1)
+             └─ SalesOfferPackageElement (0..n)
+                 ├─ @order (1..1)
+                 └─ PreassignedFareProductRef/@ref (1..1)
+```
+
+## Table
+
+| Element | Type | Description | Path |
+|---------|------|-------------|------|
+| @id | ID | Unique identifier for the FareFrame | FareFrame/@id |
+| @version | String | Version number for change tracking | FareFrame/@version |
+| tariffs | Container | Collection of tariff definitions | FareFrame/tariffs |
+| Tariff | Element | Fare structure and pricing rules | FareFrame/tariffs/Tariff |
+| Name | String | Name of the tariff | FareFrame/tariffs/Tariff/Name |
+| validableElements | Container | Collection of validable element definitions | FareFrame/validableElements |
+| ValidableElement | Element | Travel right that can be validated | FareFrame/validableElements/ValidableElement |
+| Name | String | Name of the validable element | FareFrame/validableElements/ValidableElement/Name |
+| fareProducts | Container | Collection of fare product definitions | FareFrame/fareProducts |
+| PreassignedFareProduct | Element | Pre-defined fare product (e.g., single ticket) | FareFrame/fareProducts/PreassignedFareProduct |
+| Name | String | Name of the fare product | FareFrame/fareProducts/PreassignedFareProduct/Name |
+| accessRightsInProduct | Container | Collection of access rights | FareFrame/fareProducts/PreassignedFareProduct/accessRightsInProduct |
+| AccessRightInProduct | Element | Individual access right within a fare product | FareFrame/fareProducts/PreassignedFareProduct/accessRightsInProduct/AccessRightInProduct |
+| ValidableElementRef/@ref | Reference | Reference to a ValidableElement | FareFrame/fareProducts/PreassignedFareProduct/accessRightsInProduct/AccessRightInProduct/ValidableElementRef/@ref |
+| tariffs | Container | Tariff references for the fare product | FareFrame/fareProducts/PreassignedFareProduct/tariffs |
+| TariffRef/@ref | Reference | Reference to a Tariff | FareFrame/fareProducts/PreassignedFareProduct/tariffs/TariffRef/@ref |
+| salesOfferPackages | Container | Collection of sales offer package definitions | FareFrame/salesOfferPackages |
+| SalesOfferPackage | Element | Bundle of fare products available for sale | FareFrame/salesOfferPackages/SalesOfferPackage |
+| Name | String | Name of the sales offer package | FareFrame/salesOfferPackages/SalesOfferPackage/Name |
+| salesOfferPackageElements | Container | Collection of package elements | FareFrame/salesOfferPackages/SalesOfferPackage/salesOfferPackageElements |
+| SalesOfferPackageElement | Element | Individual element within a sales offer package | FareFrame/salesOfferPackages/SalesOfferPackage/salesOfferPackageElements/SalesOfferPackageElement |
+| @order | Integer | Order of the element within the package | FareFrame/salesOfferPackages/SalesOfferPackage/salesOfferPackageElements/SalesOfferPackageElement/@order |
+| PreassignedFareProductRef/@ref | Reference | Reference to a PreassignedFareProduct | FareFrame/salesOfferPackages/SalesOfferPackage/salesOfferPackageElements/SalesOfferPackageElement/PreassignedFareProductRef/@ref |

--- a/Frames/ResourceFrame/Description_ResourceFrame.md
+++ b/Frames/ResourceFrame/Description_ResourceFrame.md
@@ -4,7 +4,21 @@
 
 A **ResourceFrame** contains shared resources used across other frames in a NeTEx delivery. It defines the organisations (Authorities and Operators), vehicle types, vehicles, and other common reference data that other frames depend on.
 
-## 2. Contained Elements
+## 2. Structure Overview
+
+```text
+📄 @id (1..1)
+📄 @version (1..1)
+📁 organisations (0..1)
+   ├── 📄 Authority (0..n)
+   └── 📄 Operator (0..n)
+📁 vehicleTypes (0..1)
+   └── 📄 VehicleType (0..n)
+📁 vehicles (0..1)
+   └── 📄 Vehicle (0..n)
+```
+
+## 3. Contained Elements
 
 - **organisations** – Collection of organisational entities:
   - [Authority](../../Objects/Authority/Table_Authority.md) – Public transport planning and regulatory bodies
@@ -12,11 +26,11 @@ A **ResourceFrame** contains shared resources used across other frames in a NeTE
 - **vehicleTypes** – Collection of [VehicleType](../../Objects/VehicleType/Table_VehicleType.md) definitions describing vehicle characteristics
 - **vehicles** – Collection of [Vehicle](../../Objects/Vehicle/Table_Vehicle.md) instances with references to their VehicleType
 
-## 3. Frame Relationships
+## 4. Frame Relationships
 
 ResourceFrame is typically the first frame in a CompositeFrame because other frames depend on its definitions. **ServiceFrame** references Operators defined here for Line assignments. **TimetableFrame** and **VehicleScheduleFrame** may reference Vehicles and VehicleTypes. All frames share the organisational context established by ResourceFrame.
 
-## 4. Usage Notes
+## 5. Usage Notes
 
 - ResourceFrame should appear before other frames in a CompositeFrame when those frames reference its Operators, Authorities, or Vehicles.
 - A single delivery typically contains one ResourceFrame, but multiple are allowed if they cover different codespaces.

--- a/Frames/ResourceFrame/Description_ResourceFrame.md
+++ b/Frames/ResourceFrame/Description_ResourceFrame.md
@@ -1,21 +1,25 @@
-# ResourceFrame – description
+# ResourceFrame
 
-**Purpose:** Common resources shared across other frames (organisations, code lists, types, responsibilities).
+## 1. Purpose
 
-**Typical elements:** Organisations (Authority/Operator), ResponsibilitySet, TypesOfValue, Codespaces.
+A **ResourceFrame** contains shared resources used across other frames in a NeTEx delivery. It defines the organisations (Authorities and Operators), vehicle types, vehicles, and other common reference data that other frames depend on.
 
-**Keys:** id, version, codespace, dataSourceRef.
+## 2. Contained Elements
 
-**Example:**
-```xml
-<netex:ResourceFrame id="NO:ResourceFrame:1" version="1">
-  <netex:organisations>
-    <netex:Authority id="NO:Authority:ENTUR" version="1"/>
-  </netex:organisations>
-  <netex:typesOfValue>
-    <netex:TypeOfValue id="NO:TOV:LineType:bus" version="1" name="bus"/>
-  </netex:typesOfValue>
-</netex:ResourceFrame>
-```
+- **organisations** – Collection of organisational entities:
+  - [Authority](../../Objects/Authority/Table_Authority.md) – Public transport planning and regulatory bodies
+  - [Operator](../../Objects/Operator/Table_Operator.md) – Service providers contracted to run transport services
+- **vehicleTypes** – Collection of [VehicleType](../../Objects/VehicleType/Table_VehicleType.md) definitions describing vehicle characteristics
+- **vehicles** – Collection of [Vehicle](../../Objects/Vehicle/Table_Vehicle.md) instances with references to their VehicleType
 
-**XSD:** See definitions for ResourceFrame in NeTEx.
+## 3. Frame Relationships
+
+ResourceFrame is typically the first frame in a CompositeFrame because other frames depend on its definitions. **ServiceFrame** references Operators defined here for Line assignments. **TimetableFrame** and **VehicleScheduleFrame** may reference Vehicles and VehicleTypes. All frames share the organisational context established by ResourceFrame.
+
+## 4. Usage Notes
+
+- ResourceFrame should appear before other frames in a CompositeFrame when those frames reference its Operators, Authorities, or Vehicles.
+- A single delivery typically contains one ResourceFrame, but multiple are allowed if they cover different codespaces.
+
+For the full structural specification, see [Table — ResourceFrame](Table_ResourceFrame.md).
+Example XML: [Example_ResourceFrame.xml](Example_ResourceFrame.xml)

--- a/Frames/ResourceFrame/Table_ResourceFrame.md
+++ b/Frames/ResourceFrame/Table_ResourceFrame.md
@@ -1,0 +1,30 @@
+# ResourceFrame
+
+## Structure Overview
+
+```text
+ResourceFrame
+ ├─ @id (1..1)
+ ├─ @version (1..1)
+ ├─ organisations (0..1)
+ │   ├─ Authority (0..n)
+ │   └─ Operator (0..n)
+ ├─ vehicleTypes (0..1)
+ │   └─ VehicleType (0..n)
+ └─ vehicles (0..1)
+     └─ Vehicle (0..n)
+```
+
+## Table
+
+| Element | Type | Description | Path |
+|---------|------|-------------|------|
+| @id | ID | Unique identifier for the ResourceFrame | ResourceFrame/@id |
+| @version | String | Version number for change tracking | ResourceFrame/@version |
+| organisations | Container | Collection of organisational entities | ResourceFrame/organisations |
+| [Authority](../../Objects/Authority/Table_Authority.md) | Element | Public transport authority | ResourceFrame/organisations/Authority |
+| [Operator](../../Objects/Operator/Table_Operator.md) | Element | Service provider organisation | ResourceFrame/organisations/Operator |
+| vehicleTypes | Container | Collection of vehicle type definitions | ResourceFrame/vehicleTypes |
+| [VehicleType](../../Objects/VehicleType/Table_VehicleType.md) | Element | Vehicle type specification | ResourceFrame/vehicleTypes/VehicleType |
+| vehicles | Container | Collection of vehicle instances | ResourceFrame/vehicles |
+| [Vehicle](../../Objects/Vehicle/Table_Vehicle.md) | Element | Individual vehicle with VehicleTypeRef | ResourceFrame/vehicles/Vehicle |

--- a/Frames/SalesTransactionFrame/Description_SalesTransactionFrame.md
+++ b/Frames/SalesTransactionFrame/Description_SalesTransactionFrame.md
@@ -4,11 +4,20 @@
 
 A **SalesTransactionFrame** is used to exchange sales-related data including fare contracts and their entries. It carries [FareContract](../../Objects/FareContract/Table_FareContract.md) objects that represent the commercial agreement between a passenger and a transport provider.
 
-## 2. Contained Elements
+## 2. Structure Overview
+
+```text
+📄 @id (1..1)
+📄 @version (1..1)
+📁 fareContracts (0..1)
+   └── 📄 FareContract (0..n)
+```
+
+## 3. Contained Elements
 
 - **fareContracts** – Collection of [FareContract](../../Objects/FareContract/Table_FareContract.md) definitions representing sales agreements with passengers
 
-## 3. Frame Relationships
+## 4. Frame Relationships
 
 SalesTransactionFrame depends on **FareFrame** for the fare products and sales offer packages that contracts reference. It is typically wrapped in a **CompositeFrame** within a PublicationDelivery.
 

--- a/Frames/SalesTransactionFrame/Description_SalesTransactionFrame.md
+++ b/Frames/SalesTransactionFrame/Description_SalesTransactionFrame.md
@@ -1,7 +1,15 @@
-# SalesTransactionFrame (Part 3 – Sales)
+# SalesTransactionFrame
 
-This frame is used to exchange sales-related data including contract objects. FareContract and FareContractEntry are carried in SalesTransactionFrame under the fareContracts container.
+## 1. Purpose
 
-Relevant schemas for the exchange:
-- netex_salesContract_version.xsd
-- netex_salesTransaction_version.xsd
+A **SalesTransactionFrame** is used to exchange sales-related data including fare contracts and their entries. It carries [FareContract](../../Objects/FareContract/Table_FareContract.md) objects that represent the commercial agreement between a passenger and a transport provider.
+
+## 2. Contained Elements
+
+- **fareContracts** – Collection of [FareContract](../../Objects/FareContract/Table_FareContract.md) definitions representing sales agreements with passengers
+
+## 3. Frame Relationships
+
+SalesTransactionFrame depends on **FareFrame** for the fare products and sales offer packages that contracts reference. It is typically wrapped in a **CompositeFrame** within a PublicationDelivery.
+
+For the full structural specification, see [Table — SalesTransactionFrame](Table_SalesTransactionFrame.md).

--- a/Frames/SalesTransactionFrame/Table_SalesTransactionFrame.md
+++ b/Frames/SalesTransactionFrame/Table_SalesTransactionFrame.md
@@ -1,0 +1,20 @@
+# SalesTransactionFrame
+
+## Structure Overview
+
+```text
+SalesTransactionFrame
+ ├─ @id (1..1)
+ ├─ @version (1..1)
+ └─ fareContracts (0..1)
+     └─ FareContract (0..n)
+```
+
+## Table
+
+| Element | Type | Description | Path |
+|---------|------|-------------|------|
+| @id | ID | Unique identifier for the SalesTransactionFrame | SalesTransactionFrame/@id |
+| @version | String | Version number for change tracking | SalesTransactionFrame/@version |
+| fareContracts | Container | Collection of fare contract definitions | SalesTransactionFrame/fareContracts |
+| [FareContract](../../Objects/FareContract/Table_FareContract.md) | Element | Sales agreement between passenger and provider | SalesTransactionFrame/fareContracts/FareContract |

--- a/Frames/ServiceCalendarFrame/Description_ServiceCalendarFrame.md
+++ b/Frames/ServiceCalendarFrame/Description_ServiceCalendarFrame.md
@@ -4,17 +4,40 @@
 
 A **ServiceCalendarFrame** groups calendar definitions that describe when services operate. It provides reusable day patterns, operating periods, and day-type assignments that TimetableFrame journeys reference to determine their days of operation.
 
-## 2. Contained Elements
+## 2. Structure Overview
+
+```text
+📄 @id (1..1)
+📄 @version (1..1)
+📁 dayTypes (0..1)
+   └── 📄 DayType (0..n)
+       ├── 📄 Name (0..1)
+       └── 📁 properties (0..1)
+           └── 📄 PropertyOfDay (0..n)
+               └── 📄 DaysOfWeek (0..1)
+📁 operatingPeriods (0..1)
+   └── 📄 OperatingPeriod (0..n)
+       ├── 📄 FromDate (1..1)
+       └── 📄 ToDate (1..1)
+📁 dayTypeAssignments (0..1)
+   └── 📄 DayTypeAssignment (0..n)
+       ├── 🔗 OperatingPeriodRef/@ref (0..1)
+       ├── 📄 Date (0..1)
+       ├── 🔗 DayTypeRef/@ref (1..1)
+       └── 📄 isAvailable (0..1)
+```
+
+## 3. Contained Elements
 
 - **dayTypes** – Collection of [DayType](../../Objects/DayType/Table_DayType.md) definitions describing reusable day patterns (e.g., Weekdays, Weekend) with DaysOfWeek properties
 - **operatingPeriods** – Collection of OperatingPeriod definitions specifying date-time windows (FromDate/ToDate) during which services apply
 - **dayTypeAssignments** – Collection of DayTypeAssignment definitions binding DayTypes to OperatingPeriods or specific dates, with isAvailable to include/exclude days
 
-## 3. Frame Relationships
+## 4. Frame Relationships
 
 ServiceCalendarFrame is referenced by **TimetableFrame** — ServiceJourneys use DayTypeRef to determine their operating days. It is independent of ServiceFrame and SiteFrame but must be present in the same CompositeFrame as the TimetableFrame that references its DayTypes.
 
-## 4. Usage Notes
+## 5. Usage Notes
 
 - DayTypeAssignments can reference either an OperatingPeriodRef (for date ranges) or a specific Date element (for individual days).
 - Use `isAvailable` set to `false` on a DayTypeAssignment to create exception dates (e.g., public holidays).

--- a/Frames/ServiceCalendarFrame/Description_ServiceCalendarFrame.md
+++ b/Frames/ServiceCalendarFrame/Description_ServiceCalendarFrame.md
@@ -1,101 +1,24 @@
 # ServiceCalendarFrame
 
-Purpose
-ServiceCalendarFrame groups calendar definitions that describe when services operate. It provides reusable day patterns and assignments for a publication period. Typical content includes:
-- DayTypes: reusable labels for day patterns (e.g., Weekdays, Weekend) with days of week.
-- OperatingPeriods: date-time windows during which a DayType (or time bands) apply.
-- DayTypeAssignments: binds DayTypes to date ranges or specific dates, including exceptions.
-- OperatingDays: optional explicit list of individual operating dates when a more granular control is needed.
+## 1. Purpose
 
-Typical elements explained
-- DayTypes
-  - Defines reusable day patterns. Use properties/PropertyOfDay/DaysOfWeek to declare days (e.g., Monday Tuesday ...).
-  - Can be combined with OperatingPeriods in DayTypeAssignments.
-- OperatingPeriods
-  - Defines a validity window with FromDate and ToDate as xs:dateTime (e.g., 2026-03-01T00:00:00Z).
-  - Usually referenced by OperatingPeriodRef from DayTypeAssignment.
-- DayTypeAssignments
-  - Connects a DayType to a date (Date) or to an OperatingPeriod (OperatingPeriodRef).
-  - Use isAvailable element to include/exclude a day; set to false for exception dates.
-  - order attribute can be used to control evaluation order when multiple assignments may overlap.
-- OperatingDays
-  - Explicit dates of operation; useful for enumerated calendars or to represent special schedules.
+A **ServiceCalendarFrame** groups calendar definitions that describe when services operate. It provides reusable day patterns, operating periods, and day-type assignments that TimetableFrame journeys reference to determine their days of operation.
 
-Keys, versioning and references
-- id and version
-  - Use a stable, globally unique id within your codespace. Example patterns:
-    - ERP:ServiceCalendarFrame:1, ERP:DayType:Weekday, ERP:OperatingPeriod:2026-Q2
-  - version should be incremented when a logical change is made; use positive integers as strings (e.g., "1", "2").
-- References (OperatingPeriodRef, DayTypeRef)
-  - Always provide @ref pointing to the target object id and a matching @versionRef.
-  - Example: <OperatingPeriodRef ref="ERP:OperatingPeriod:2026-Q2" versionRef="1"/>
+## 2. Contained Elements
 
-Complete, valid NeTEx 2.0 example
-The following PublicationDelivery contains a CompositeFrame with one ServiceCalendarFrame that defines weekday and weekend patterns for a period, binds them via DayTypeAssignments, and adds a single exception day with isAvailable=false. Codespace used: ERP.
+- **dayTypes** – Collection of [DayType](../../Objects/DayType/Table_DayType.md) definitions describing reusable day patterns (e.g., Weekdays, Weekend) with DaysOfWeek properties
+- **operatingPeriods** – Collection of OperatingPeriod definitions specifying date-time windows (FromDate/ToDate) during which services apply
+- **dayTypeAssignments** – Collection of DayTypeAssignment definitions binding DayTypes to OperatingPeriods or specific dates, with isAvailable to include/exclude days
 
-```xml
-<?xml version="1.0" encoding="UTF-8"?>
-<PublicationDelivery xmlns="http://www.netex.org.uk/netex" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="2.0">
-  <PublicationTimestamp>2026-02-27T23:25:00Z</PublicationTimestamp>
-  <ParticipantRef>ERP:Participant:ENTUR</ParticipantRef>
-  <Description>Service calendar example with DayTypes, OperatingPeriod, DayTypeAssignments and exception date.</Description>
-  <dataObjects>
-    <CompositeFrame id="ERP:CompositeFrame:ServiceCalendar:1" version="1">
-      <Name>Service Calendar Package</Name>
-      <frames>
-        <ServiceCalendarFrame id="ERP:ServiceCalendarFrame:1" version="1">
-          <Name>Service Calendar 2026 Q2</Name>
-          <dayTypes>
-            <DayType id="ERP:DayType:Weekday" version="1">
-              <Name>Weekdays</Name>
-              <properties>
-                <PropertyOfDay>
-                  <DaysOfWeek>Monday Tuesday Wednesday Thursday Friday</DaysOfWeek>
-                </PropertyOfDay>
-              </properties>
-            </DayType>
-            <DayType id="ERP:DayType:Weekend" version="1">
-              <Name>Weekend</Name>
-              <properties>
-                <PropertyOfDay>
-                  <DaysOfWeek>Saturday Sunday</DaysOfWeek>
-                </PropertyOfDay>
-              </properties>
-            </DayType>
-          </dayTypes>
-          <operatingPeriods>
-            <OperatingPeriod id="ERP:OperatingPeriod:2026-Q2" version="1">
-              <FromDate>2026-03-01T00:00:00Z</FromDate>
-              <ToDate>2026-06-30T23:59:59Z</ToDate>
-            </OperatingPeriod>
-          </operatingPeriods>
-          <dayTypeAssignments>
-            <DayTypeAssignment id="ERP:DayTypeAssignment:Weekday:Q2" version="1" order="1">
-              <OperatingPeriodRef ref="ERP:OperatingPeriod:2026-Q2" versionRef="1"/>
-              <DayTypeRef ref="ERP:DayType:Weekday" versionRef="1"/>
-            </DayTypeAssignment>
-            <DayTypeAssignment id="ERP:DayTypeAssignment:Weekend:Q2" version="1" order="2">
-              <OperatingPeriodRef ref="ERP:OperatingPeriod:2026-Q2" versionRef="1"/>
-              <DayTypeRef ref="ERP:DayType:Weekend" versionRef="1"/>
-            </DayTypeAssignment>
-            <DayTypeAssignment id="ERP:DayTypeAssignment:Exception:LabourDay" version="1" order="3">
-              <Date>2026-05-01</Date>
-              <DayTypeRef ref="ERP:DayType:Weekday" versionRef="1"/>
-              <isAvailable>false</isAvailable>
-            </DayTypeAssignment>
-          </dayTypeAssignments>
-        </ServiceCalendarFrame>
-      </frames>
-    </CompositeFrame>
-  </dataObjects>
-</PublicationDelivery>
-```
+## 3. Frame Relationships
 
-Validation notes
-- This example is valid against NeTEx 2.0 schemas and was validated before inclusion.
-- For production, validate PublicationDelivery documents against netex_publication.xsd.
-- netex_publication_noConstraint.xsd is for development/debugging only and SHOULD NOT be used in production.
+ServiceCalendarFrame is referenced by **TimetableFrame** — ServiceJourneys use DayTypeRef to determine their operating days. It is independent of ServiceFrame and SiteFrame but must be present in the same CompositeFrame as the TimetableFrame that references its DayTypes.
 
-See also
-- Frames overview: ../FramesOverview.md
-- XSD 2.0/README: ../../XSD%202.0/README.md
+## 4. Usage Notes
+
+- DayTypeAssignments can reference either an OperatingPeriodRef (for date ranges) or a specific Date element (for individual days).
+- Use `isAvailable` set to `false` on a DayTypeAssignment to create exception dates (e.g., public holidays).
+- The `order` attribute on DayTypeAssignment controls evaluation order when multiple assignments overlap.
+
+For the full structural specification, see [Table — ServiceCalendarFrame](Table_ServiceCalendarFrame.md).
+Example XML: [Example_ServiceCalendarFrame.xml](Example_ServiceCalendarFrame.xml)

--- a/Frames/ServiceCalendarFrame/Table_ServiceCalendarFrame.md
+++ b/Frames/ServiceCalendarFrame/Table_ServiceCalendarFrame.md
@@ -1,0 +1,50 @@
+# ServiceCalendarFrame
+
+## Structure Overview
+
+```text
+ServiceCalendarFrame
+ ├─ @id (1..1)
+ ├─ @version (1..1)
+ ├─ dayTypes (0..1)
+ │   └─ DayType (0..n)
+ │       ├─ Name (0..1)
+ │       └─ properties (0..1)
+ │           └─ PropertyOfDay (0..n)
+ │               └─ DaysOfWeek (0..1)
+ ├─ operatingPeriods (0..1)
+ │   └─ OperatingPeriod (0..n)
+ │       ├─ FromDate (1..1)
+ │       └─ ToDate (1..1)
+ └─ dayTypeAssignments (0..1)
+     └─ DayTypeAssignment (0..n)
+         ├─ @order (0..1)
+         ├─ OperatingPeriodRef/@ref (0..1)
+         ├─ Date (0..1)
+         ├─ DayTypeRef/@ref (1..1)
+         └─ isAvailable (0..1)
+```
+
+## Table
+
+| Element | Type | Description | Path |
+|---------|------|-------------|------|
+| @id | ID | Unique identifier for the ServiceCalendarFrame | ServiceCalendarFrame/@id |
+| @version | String | Version number for change tracking | ServiceCalendarFrame/@version |
+| dayTypes | Container | Collection of day type definitions | ServiceCalendarFrame/dayTypes |
+| [DayType](../../Objects/DayType/Table_DayType.md) | Element | Reusable day pattern (e.g., Weekdays, Weekend) | ServiceCalendarFrame/dayTypes/DayType |
+| Name | String | Human-readable name of the day type | ServiceCalendarFrame/dayTypes/DayType/Name |
+| properties | Container | Collection of day properties | ServiceCalendarFrame/dayTypes/DayType/properties |
+| PropertyOfDay | Element | Day-of-week specification | ServiceCalendarFrame/dayTypes/DayType/properties/PropertyOfDay |
+| DaysOfWeek | String | Space-separated list of day names | ServiceCalendarFrame/dayTypes/DayType/properties/PropertyOfDay/DaysOfWeek |
+| operatingPeriods | Container | Collection of operating period definitions | ServiceCalendarFrame/operatingPeriods |
+| OperatingPeriod | Element | Date-time window of validity | ServiceCalendarFrame/operatingPeriods/OperatingPeriod |
+| FromDate | DateTime | Start of the operating period | ServiceCalendarFrame/operatingPeriods/OperatingPeriod/FromDate |
+| ToDate | DateTime | End of the operating period | ServiceCalendarFrame/operatingPeriods/OperatingPeriod/ToDate |
+| dayTypeAssignments | Container | Collection of day type assignment definitions | ServiceCalendarFrame/dayTypeAssignments |
+| DayTypeAssignment | Element | Binds a DayType to a period or date | ServiceCalendarFrame/dayTypeAssignments/DayTypeAssignment |
+| @order | Integer | Evaluation order for overlapping assignments | ServiceCalendarFrame/dayTypeAssignments/DayTypeAssignment/@order |
+| OperatingPeriodRef/@ref | Reference | Reference to an OperatingPeriod | ServiceCalendarFrame/dayTypeAssignments/DayTypeAssignment/OperatingPeriodRef/@ref |
+| Date | Date | Specific date for the assignment | ServiceCalendarFrame/dayTypeAssignments/DayTypeAssignment/Date |
+| DayTypeRef/@ref | Reference | Reference to a DayType | ServiceCalendarFrame/dayTypeAssignments/DayTypeAssignment/DayTypeRef/@ref |
+| isAvailable | Boolean | Whether the day type is available (false for exceptions) | ServiceCalendarFrame/dayTypeAssignments/DayTypeAssignment/isAvailable |

--- a/Frames/ServiceFrame/Description_ServiceFrame.md
+++ b/Frames/ServiceFrame/Description_ServiceFrame.md
@@ -1,21 +1,16 @@
-# ServiceFrame – description
+# ServiceFrame
 
-**Purpose:** Network and route offer; lines, routes, and patterns for traffic.
+## 1. Purpose
 
-**Typical elements:** Lines, Routes, RoutePoints/Links, ServiceLinks, DestinationDisplays, StopAssignments.
+A **ServiceFrame** contains the network and route definitions for a public transport delivery. It groups Lines, Routes, JourneyPatterns, ScheduledStopPoints, DestinationDisplays, and PassengerStopAssignments — the structural elements that describe where and how services run.
 
-**Keys:** id, version, routeRef/serviceLinkRef/lineRef.
+## 2. Contained Elements
 
-**Example:**
-```xml
-<netex:ServiceFrame id="NO:ServiceFrame:1" version="1">
-  <netex:lines>
-    <netex:Line id="NO:Line:10" version="1" name="Linje 10"/>
-  </netex:lines>
-  <netex:routes>
-    <netex:Route id="NO:Route:10A" version="1"/>
-  </netex:routes>
-</netex:ServiceFrame>
-```
+- **lines** – Collection of [Line](../../Objects/Line/Table_Line.md) definitions describing transport services
 
-**XSD:** See ServiceFrame in NeTEx.
+## 3. Frame Relationships
+
+ServiceFrame depends on **ResourceFrame** for Operator and Authority definitions referenced by Lines. **TimetableFrame** depends on ServiceFrame for JourneyPatterns and Lines used by ServiceJourneys. **SiteFrame** provides the physical stop infrastructure (StopPlaces, Quays) that PassengerStopAssignments link to. All frames are typically wrapped in a **CompositeFrame** within a PublicationDelivery.
+
+For the full structural specification, see [Table — ServiceFrame](Table_ServiceFrame.md).
+Example XML: [Example_ServiceFrame.xml](Example_ServiceFrame.xml)

--- a/Frames/ServiceFrame/Description_ServiceFrame.md
+++ b/Frames/ServiceFrame/Description_ServiceFrame.md
@@ -4,11 +4,20 @@
 
 A **ServiceFrame** contains the network and route definitions for a public transport delivery. It groups Lines, Routes, JourneyPatterns, ScheduledStopPoints, DestinationDisplays, and PassengerStopAssignments — the structural elements that describe where and how services run.
 
-## 2. Contained Elements
+## 2. Structure Overview
+
+```text
+📄 @id (1..1)
+📄 @version (1..1)
+📁 lines (0..1)
+   └── 📄 Line (0..n)
+```
+
+## 3. Contained Elements
 
 - **lines** – Collection of [Line](../../Objects/Line/Table_Line.md) definitions describing transport services
 
-## 3. Frame Relationships
+## 4. Frame Relationships
 
 ServiceFrame depends on **ResourceFrame** for Operator and Authority definitions referenced by Lines. **TimetableFrame** depends on ServiceFrame for JourneyPatterns and Lines used by ServiceJourneys. **SiteFrame** provides the physical stop infrastructure (StopPlaces, Quays) that PassengerStopAssignments link to. All frames are typically wrapped in a **CompositeFrame** within a PublicationDelivery.
 

--- a/Frames/ServiceFrame/Table_ServiceFrame.md
+++ b/Frames/ServiceFrame/Table_ServiceFrame.md
@@ -1,0 +1,20 @@
+# ServiceFrame
+
+## Structure Overview
+
+```text
+ServiceFrame
+ ├─ @id (1..1)
+ ├─ @version (1..1)
+ └─ lines (0..1)
+     └─ Line (0..n)
+```
+
+## Table
+
+| Element | Type | Description | Path |
+|---------|------|-------------|------|
+| @id | ID | Unique identifier for the ServiceFrame | ServiceFrame/@id |
+| @version | String | Version number for change tracking | ServiceFrame/@version |
+| lines | Container | Collection of Line definitions | ServiceFrame/lines |
+| [Line](../../Objects/Line/Table_Line.md) | Element | Transport line with name, public code, and operator reference | ServiceFrame/lines/Line |

--- a/Frames/SiteFrame/Description_SiteFrame.md
+++ b/Frames/SiteFrame/Description_SiteFrame.md
@@ -1,22 +1,16 @@
-# SiteFrame – description
+# SiteFrame
 
-**Purpose:** Site model (stop places, terminals, entrances, walking links).
+## 1. Purpose
 
-**Typical elements:** StopPlace (with Quay), Access/Entrance, PathLink, NavigationPath, Parking.
+A **SiteFrame** contains the physical infrastructure model for public transport — stop places, quays, entrances, parking facilities, and topographic context. It defines the spatial elements that passengers interact with and that other frames reference for stop assignments.
 
-**Keys:** id, version, stopPlaceRef/quayRef/pathLinkRef.
+## 2. Contained Elements
 
-**Example:**
-```xml
-<netex:SiteFrame id="NO:SiteFrame:1" version="1">
-  <netex:stopPlaces>
-    <netex:StopPlace id="NO:StopPlace:123" version="1" name="Jernbanetorget">
-      <netex:quays>
-        <netex:Quay id="NO:Quay:123-1" version="1"/>
-      </netex:quays>
-    </netex:StopPlace>
-  </netex:stopPlaces>
-</netex:SiteFrame>
-```
+- **stopPlaces** – Collection of [StopPlace](../../Objects/StopPlace/Table_StopPlace.md) definitions, each containing one or more [Quay](../../Objects/Quay/Table_Quay.md) elements
 
-**XSD:** See SiteFrame in NeTEx.
+## 3. Frame Relationships
+
+SiteFrame is independent of other frames but provides the physical stop infrastructure that **ServiceFrame** references through PassengerStopAssignments. **TimetableFrame** indirectly depends on SiteFrame through the JourneyPattern stop sequence. SiteFrame is typically wrapped in a **CompositeFrame** within a PublicationDelivery.
+
+For the full structural specification, see [Table — SiteFrame](Table_SiteFrame.md).
+Example XML: [Example_SiteFrame.xml](Example_SiteFrame.xml)

--- a/Frames/SiteFrame/Description_SiteFrame.md
+++ b/Frames/SiteFrame/Description_SiteFrame.md
@@ -4,11 +4,24 @@
 
 A **SiteFrame** contains the physical infrastructure model for public transport — stop places, quays, entrances, parking facilities, and topographic context. It defines the spatial elements that passengers interact with and that other frames reference for stop assignments.
 
-## 2. Contained Elements
+## 2. Structure Overview
+
+```text
+📄 @id (1..1)
+📄 @version (1..1)
+📁 stopPlaces (0..1)
+   └── 📄 StopPlace (0..n)
+       ├── 📄 Name (0..1)
+       └── 📁 quays (0..1)
+           └── 📄 Quay (0..n)
+               └── 📄 Name (0..1)
+```
+
+## 3. Contained Elements
 
 - **stopPlaces** – Collection of [StopPlace](../../Objects/StopPlace/Table_StopPlace.md) definitions, each containing one or more [Quay](../../Objects/Quay/Table_Quay.md) elements
 
-## 3. Frame Relationships
+## 4. Frame Relationships
 
 SiteFrame is independent of other frames but provides the physical stop infrastructure that **ServiceFrame** references through PassengerStopAssignments. **TimetableFrame** indirectly depends on SiteFrame through the JourneyPattern stop sequence. SiteFrame is typically wrapped in a **CompositeFrame** within a PublicationDelivery.
 

--- a/Frames/SiteFrame/Table_SiteFrame.md
+++ b/Frames/SiteFrame/Table_SiteFrame.md
@@ -1,0 +1,28 @@
+# SiteFrame
+
+## Structure Overview
+
+```text
+SiteFrame
+ ├─ @id (1..1)
+ ├─ @version (1..1)
+ └─ stopPlaces (0..1)
+     └─ StopPlace (0..n)
+         ├─ Name (0..1)
+         └─ quays (0..1)
+             └─ Quay (0..n)
+                 └─ Name (0..1)
+```
+
+## Table
+
+| Element | Type | Description | Path |
+|---------|------|-------------|------|
+| @id | ID | Unique identifier for the SiteFrame | SiteFrame/@id |
+| @version | String | Version number for change tracking | SiteFrame/@version |
+| stopPlaces | Container | Collection of stop place definitions | SiteFrame/stopPlaces |
+| [StopPlace](../../Objects/StopPlace/Table_StopPlace.md) | Element | Physical stop location with quays | SiteFrame/stopPlaces/StopPlace |
+| Name | String | Name of the stop place | SiteFrame/stopPlaces/StopPlace/Name |
+| quays | Container | Collection of quays within a stop place | SiteFrame/stopPlaces/StopPlace/quays |
+| [Quay](../../Objects/Quay/Table_Quay.md) | Element | Individual boarding/alighting point | SiteFrame/stopPlaces/StopPlace/quays/Quay |
+| Name | String | Name of the quay | SiteFrame/stopPlaces/StopPlace/quays/Quay/Name |

--- a/Frames/TimetableFrame/Description_TimetableFrame.md
+++ b/Frames/TimetableFrame/Description_TimetableFrame.md
@@ -4,7 +4,23 @@
 
 A **TimetableFrame** contains the operational journey definitions — the actual trips that run on the network. It groups ServiceJourneys, DatedServiceJourneys, DeadRuns, coupled journeys, and interchange rules that together describe the timetabled service offering.
 
-## 2. Contained Elements
+## 2. Structure Overview
+
+```text
+📄 @id (1..1)
+📄 @version (1..1)
+📁 vehicleJourneys (0..1)
+   ├── 📄 ServiceJourney (0..n)
+   ├── 📄 DatedServiceJourney (0..n)
+   ├── 📄 DatedVehicleJourney (0..n)
+   └── 📄 DeadRun (0..n)
+📁 coupledJourneys (0..1)
+   └── 📄 CoupledJourney (0..n)
+📁 interchangeRules (0..1)
+   └── 📄 InterchangeRule (0..n)
+```
+
+## 3. Contained Elements
 
 - **vehicleJourneys** – Collection of journey types:
   - [ServiceJourney](../../Objects/ServiceJourney/Table_ServiceJourney.md) – Planned passenger-carrying trips on a recurring schedule
@@ -14,7 +30,7 @@ A **TimetableFrame** contains the operational journey definitions — the actual
 - **coupledJourneys** – Collection of CoupledJourney definitions linking journeys that run coupled together
 - **interchangeRules** – Collection of InterchangeRule definitions for guaranteed or timed connections between journeys
 
-## 3. Frame Relationships
+## 4. Frame Relationships
 
 TimetableFrame depends on **ServiceFrame** for JourneyPatterns and Lines referenced by ServiceJourneys. It depends on **ResourceFrame** for Operator definitions. **VehicleScheduleFrame** may reference journeys defined here for block and duty scheduling. TimetableFrame is typically wrapped in a **CompositeFrame** within a PublicationDelivery.
 

--- a/Frames/TimetableFrame/Description_TimetableFrame.md
+++ b/Frames/TimetableFrame/Description_TimetableFrame.md
@@ -1,22 +1,22 @@
-# TimetableFrame – description
+# TimetableFrame
 
-**Purpose:** Operational journeys/times for the public; departure and arrival times.
+## 1. Purpose
 
-**Typical elements:** ServiceJourney/VehicleJourney, DayType associations, PassingTimes.
+A **TimetableFrame** contains the operational journey definitions — the actual trips that run on the network. It groups ServiceJourneys, DatedServiceJourneys, DeadRuns, coupled journeys, and interchange rules that together describe the timetabled service offering.
 
-**Keys:** id, version, journeyPatternRef/serviceJourneyPatternRef, dayTypeRef.
+## 2. Contained Elements
 
-**Example:**
-```xml
-<netex:TimetableFrame id="NO:TimetableFrame:1" version="1">
-  <netex:vehicleJourneys>
-    <netex:ServiceJourney id="NO:SJ:10-1" version="1" lineRef="NO:Line:10">
-      <netex:passingTimes>
-        <netex:TimetabledPassingTime stopPointInJourneyPatternRef="NO:SPJP:1" departureTime="08:00:00"/>
-      </netex:passingTimes>
-    </netex:ServiceJourney>
-  </netex:vehicleJourneys>
-</netex:TimetableFrame>
-```
+- **vehicleJourneys** – Collection of journey types:
+  - [ServiceJourney](../../Objects/ServiceJourney/Table_ServiceJourney.md) – Planned passenger-carrying trips on a recurring schedule
+  - [DatedServiceJourney](../../Objects/DatedServiceJourney/Table_DatedServiceJourney.md) – Date-specific instances of a ServiceJourney
+  - DatedVehicleJourney – Date-specific vehicle journey (may include non-passenger moves)
+  - DeadRun – Non-passenger vehicle repositioning movement
+- **coupledJourneys** – Collection of CoupledJourney definitions linking journeys that run coupled together
+- **interchangeRules** – Collection of InterchangeRule definitions for guaranteed or timed connections between journeys
 
-**XSD:** See TimetableFrame in NeTEx.
+## 3. Frame Relationships
+
+TimetableFrame depends on **ServiceFrame** for JourneyPatterns and Lines referenced by ServiceJourneys. It depends on **ResourceFrame** for Operator definitions. **VehicleScheduleFrame** may reference journeys defined here for block and duty scheduling. TimetableFrame is typically wrapped in a **CompositeFrame** within a PublicationDelivery.
+
+For the full structural specification, see [Table — TimetableFrame](Table_TimetableFrame.md).
+Example XML: [Example_TimetableFrame.xml](Example_TimetableFrame.xml)

--- a/Frames/TimetableFrame/Table_TimetableFrame.md
+++ b/Frames/TimetableFrame/Table_TimetableFrame.md
@@ -1,0 +1,34 @@
+# TimetableFrame
+
+## Structure Overview
+
+```text
+TimetableFrame
+ ├─ @id (1..1)
+ ├─ @version (1..1)
+ ├─ vehicleJourneys (0..1)
+ │   ├─ ServiceJourney (0..n)
+ │   ├─ DatedServiceJourney (0..n)
+ │   ├─ DatedVehicleJourney (0..n)
+ │   └─ DeadRun (0..n)
+ ├─ coupledJourneys (0..1)
+ │   └─ CoupledJourney (0..n)
+ └─ interchangeRules (0..1)
+     └─ InterchangeRule (0..n)
+```
+
+## Table
+
+| Element | Type | Description | Path |
+|---------|------|-------------|------|
+| @id | ID | Unique identifier for the TimetableFrame | TimetableFrame/@id |
+| @version | String | Version number for change tracking | TimetableFrame/@version |
+| vehicleJourneys | Container | Collection of journey definitions | TimetableFrame/vehicleJourneys |
+| [ServiceJourney](../../Objects/ServiceJourney/Table_ServiceJourney.md) | Element | Planned passenger-carrying trip | TimetableFrame/vehicleJourneys/ServiceJourney |
+| [DatedServiceJourney](../../Objects/DatedServiceJourney/Table_DatedServiceJourney.md) | Element | Date-specific instance of a ServiceJourney | TimetableFrame/vehicleJourneys/DatedServiceJourney |
+| DatedVehicleJourney | Element | Date-specific vehicle journey | TimetableFrame/vehicleJourneys/DatedVehicleJourney |
+| DeadRun | Element | Non-passenger vehicle repositioning movement | TimetableFrame/vehicleJourneys/DeadRun |
+| coupledJourneys | Container | Collection of coupled journey definitions | TimetableFrame/coupledJourneys |
+| CoupledJourney | Element | Linking of journeys that run coupled together | TimetableFrame/coupledJourneys/CoupledJourney |
+| interchangeRules | Container | Collection of interchange rule definitions | TimetableFrame/interchangeRules |
+| InterchangeRule | Element | Guaranteed or timed connection between journeys | TimetableFrame/interchangeRules/InterchangeRule |

--- a/Frames/VehicleScheduleFrame/Description_VehicleScheduleFrame.md
+++ b/Frames/VehicleScheduleFrame/Description_VehicleScheduleFrame.md
@@ -1,18 +1,18 @@
-# VehicleScheduleFrame – description
+# VehicleScheduleFrame
 
-**Purpose:** Operational vehicle schedules; blocks, duties, and assignments.
+## 1. Purpose
 
-**Typical elements:** Blocks, VehicleServices, VehicleTypeAssignments, Duties.
+A **VehicleScheduleFrame** contains operational vehicle schedules — the blocks, vehicle services, and duty assignments that define how vehicles are allocated to journeys throughout the operating day.
 
-**Keys:** id, version, vehicleServiceRef/blockRef.
+## 2. Contained Elements
 
-**Example:**
-```xml
-<netex:VehicleScheduleFrame id="NO:VehicleScheduleFrame:1" version="1">
-  <netex:blocks>
-    <netex:Block id="NO:Block:10A" version="1"/>
-  </netex:blocks>
-</netex:VehicleScheduleFrame>
-```
+- **blocks** – Collection of block definitions grouping journeys assigned to a single vehicle:
+  - [TrainBlock](../../Objects/TrainBlock/Table_TrainBlock.md) – Block specifically for train vehicle scheduling
+- **vehicleServices** – Collection of VehicleService definitions describing a vehicle's complete service for a day
 
-**XSD:** See VehicleScheduleFrame in NeTEx.
+## 3. Frame Relationships
+
+VehicleScheduleFrame depends on **TimetableFrame** for the ServiceJourneys and DatedServiceJourneys that blocks reference. It depends on **ResourceFrame** for Vehicle and VehicleType definitions. VehicleScheduleFrame is typically wrapped in a **CompositeFrame** within a PublicationDelivery.
+
+For the full structural specification, see [Table — VehicleScheduleFrame](Table_VehicleScheduleFrame.md).
+Example XML: [Example_VehicleScheduleFrame.xml](Example_VehicleScheduleFrame.xml)

--- a/Frames/VehicleScheduleFrame/Description_VehicleScheduleFrame.md
+++ b/Frames/VehicleScheduleFrame/Description_VehicleScheduleFrame.md
@@ -4,13 +4,24 @@
 
 A **VehicleScheduleFrame** contains operational vehicle schedules — the blocks, vehicle services, and duty assignments that define how vehicles are allocated to journeys throughout the operating day.
 
-## 2. Contained Elements
+## 2. Structure Overview
+
+```text
+📄 @id (1..1)
+📄 @version (1..1)
+📁 blocks (0..1)
+   └── 📄 TrainBlock (0..n)
+📁 vehicleServices (0..1)
+   └── 📄 VehicleService (0..n)
+```
+
+## 3. Contained Elements
 
 - **blocks** – Collection of block definitions grouping journeys assigned to a single vehicle:
   - [TrainBlock](../../Objects/TrainBlock/Table_TrainBlock.md) – Block specifically for train vehicle scheduling
 - **vehicleServices** – Collection of VehicleService definitions describing a vehicle's complete service for a day
 
-## 3. Frame Relationships
+## 4. Frame Relationships
 
 VehicleScheduleFrame depends on **TimetableFrame** for the ServiceJourneys and DatedServiceJourneys that blocks reference. It depends on **ResourceFrame** for Vehicle and VehicleType definitions. VehicleScheduleFrame is typically wrapped in a **CompositeFrame** within a PublicationDelivery.
 

--- a/Frames/VehicleScheduleFrame/Table_VehicleScheduleFrame.md
+++ b/Frames/VehicleScheduleFrame/Table_VehicleScheduleFrame.md
@@ -1,0 +1,24 @@
+# VehicleScheduleFrame
+
+## Structure Overview
+
+```text
+VehicleScheduleFrame
+ ├─ @id (1..1)
+ ├─ @version (1..1)
+ ├─ blocks (0..1)
+ │   └─ TrainBlock (0..n)
+ └─ vehicleServices (0..1)
+     └─ VehicleService (0..n)
+```
+
+## Table
+
+| Element | Type | Description | Path |
+|---------|------|-------------|------|
+| @id | ID | Unique identifier for the VehicleScheduleFrame | VehicleScheduleFrame/@id |
+| @version | String | Version number for change tracking | VehicleScheduleFrame/@version |
+| blocks | Container | Collection of block definitions | VehicleScheduleFrame/blocks |
+| [TrainBlock](../../Objects/TrainBlock/Table_TrainBlock.md) | Element | Block for train vehicle scheduling | VehicleScheduleFrame/blocks/TrainBlock |
+| vehicleServices | Container | Collection of vehicle service definitions | VehicleScheduleFrame/vehicleServices |
+| VehicleService | Element | Vehicle's complete service for an operating day | VehicleScheduleFrame/vehicleServices/VehicleService |

--- a/LLM/README.md
+++ b/LLM/README.md
@@ -103,16 +103,22 @@ Every frame under `Frames/<FrameName>/` must contain the following files:
 
 A validated XML example demonstrating the frame structure, contained sub-frames, and element composition.
 
-### 5.2. `Description_<FrameName>.md` (mandatory)
+### 5.2. `Table_<FrameName>.md` (mandatory)
 
-A human‑readable explanation of the frame (optional Table file at this time).
+The structural specification file. See [Frame Table Template](Templates/Frame_Structure_and_Table_Template.md) for detailed guidance.
 
-Should include:
-- Name and purpose of the frame
-- Role and scope within the NeTEx data model
-- Contained child frames and key elements
-- Relationships to other frames
-- Typical usage patterns and data flow
+Must contain a Structure Overview and flat table with all collections, child elements, and attributes.
+
+### 5.3. `Description_<FrameName>.md` (mandatory)
+
+The semantic explanation file. See [Frame Description Template](Templates/Frame_Description_Template.md) for detailed guidance.
+
+**Must follow the mandatory 4-section template structure in exact order:**
+
+1. **Purpose** (mandatory) – Brief explanation of the frame's role and scope
+2. **Contained Elements** (mandatory) – Bulleted list of key collections with links to Object Table files
+3. **Frame Relationships** (mandatory) – Dependencies upstream and downstream
+4. **Usage Notes** (optional) – Non-obvious constraints or common mistakes
 
 ---
 
@@ -137,6 +143,7 @@ Objects/
 Frames/
 ├── <FrameName>/
 │   ├── Description_<FrameName>.md
+│   ├── Table_<FrameName>.md
 │   └── Example_<FrameName>.xml
 └── ...
 ```

--- a/LLM/README.md
+++ b/LLM/README.md
@@ -113,12 +113,13 @@ Must contain a Structure Overview and flat table with all collections, child ele
 
 The semantic explanation file. See [Frame Description Template](Templates/Frame_Description_Template.md) for detailed guidance.
 
-**Must follow the mandatory 4-section template structure in exact order:**
+**Must follow the mandatory 5-section template structure in exact order:**
 
 1. **Purpose** (mandatory) – Brief explanation of the frame's role and scope
-2. **Contained Elements** (mandatory) – Bulleted list of key collections with links to Object Table files
-3. **Frame Relationships** (mandatory) – Dependencies upstream and downstream
-4. **Usage Notes** (optional) – Non-obvious constraints or common mistakes
+2. **Structure Overview** (mandatory) – Icon-based visual representation of the frame's collections
+3. **Contained Elements** (mandatory) – Bulleted list of key collections with links to Object Table files
+4. **Frame Relationships** (mandatory) – Dependencies upstream and downstream
+5. **Usage Notes** (optional) – Non-obvious constraints or common mistakes
 
 ---
 

--- a/LLM/Templates/Frame_Description_Template.md
+++ b/LLM/Templates/Frame_Description_Template.md
@@ -6,13 +6,13 @@ This template defines the structure for all Frame description files in the NeTEx
 Frame descriptions are simpler than Object descriptions because Frames are containers that group
 related Objects rather than carrying rich domain data themselves.
 
-All description files must follow this 4-section format in the exact order specified below.
+All description files must follow this 5-section format in the exact order specified below.
 
 ---
 
 ## Mandatory Section Order
 
-**Sections 1–3 are required. Section 4 is optional.**
+**Sections 1–4 are required. Section 5 is optional.**
 All sections must appear in this exact sequence.
 
 ---
@@ -27,7 +27,53 @@ Should clarify where the frame sits in the NeTEx delivery structure (e.g., child
 
 ---
 
-## 2. Contained Elements
+## 2. Structure Overview
+
+**Required.** A visual, icon-based representation of the frame's top-level structure.
+Must follow the ordering and hierarchy shown in `Table_<FrameName>.md`.
+
+### Icon Legend
+- `📄` = Simple element or attribute (primitive data)
+- `📁` = Container element (collection)
+- `🔗` = Reference to another object (always include @ref suffix)
+
+### Cardinality Notation
+
+Use standard cardinality notation to express element requirements:
+
+| Notation | Meaning |
+| -------- | ------- |
+| `(1..1)` | Mandatory, exactly one |
+| `(1..n)` | Mandatory, one or more |
+| `(0..1)` | Optional, at most one |
+| `(0..n)` | Optional, zero or more |
+
+- Every element in the Structure Overview should include its cardinality.
+- Do **not** use words like "mandatory", "optional", or "required" — use cardinality notation instead.
+
+### Structure Example
+
+```text
+📄 @id (1..1)
+📄 @version (1..1)
+📁 organisations (0..1)
+   ├── 📄 Authority (0..n)
+   └── 📄 Operator (0..n)
+📁 vehicleTypes (0..1)
+   └── 📄 VehicleType (0..n)
+📁 vehicles (0..1)
+   └── 📄 Vehicle (0..n)
+```
+
+### Guidelines
+- Keep structure concise — show the frame's collections and their immediate children
+- Every element must show its cardinality using the notation above
+- Mirror the exact order from the XML examples
+- Use proper indentation and box-drawing lines (`├──`, `└──`)
+
+---
+
+## 3. Contained Elements
 
 **Required.** A bulleted list of the key collections and elements carried by this frame.
 Each item should name the container element and briefly describe what it holds, with links to
@@ -42,7 +88,7 @@ the relevant Object Table files where they exist.
 
 ---
 
-## 3. Frame Relationships
+## 4. Frame Relationships
 
 **Required.** Describe how this frame relates to other frames in a typical NeTEx delivery.
 Include which frames it depends on and which frames depend on it.
@@ -54,7 +100,7 @@ Include which frames it depends on and which frames depend on it.
 
 ---
 
-## 4. Usage Notes (optional)
+## 5. Usage Notes (optional)
 
 **Optional.** Any additional guidance on how to use the frame correctly.
 Include only when there are non-obvious constraints, ordering requirements, or common mistakes.
@@ -67,11 +113,13 @@ Include only when there are non-obvious constraints, ordering requirements, or c
 
 ## Section Rules & Constraints
 
-1. **Sections 1–3 are mandatory.** All must be present and in order.
-2. **Section 4 is optional.** Omit if not relevant.
+1. **Sections 1–4 are mandatory.** All must be present and in order.
+2. **Section 5 is optional.** Omit if not relevant.
 3. **No additional top-level sections.** Keep frame descriptions concise.
-4. **Use relative markdown links** to reference Object Table files: `[ObjectName](../../Objects/ObjectName/Table_ObjectName.md)`
-5. **Link to the frame's Table file** at the end of the description if one exists.
+4. **Structure Overview must use icon notation** (📄, 📁, 🔗) and match the XML example order.
+5. **Structure Overview must use cardinality notation** on every element: `(1..1)`, `(1..n)`, `(0..1)`, `(0..n)`.
+6. **Use relative markdown links** to reference Object Table files: `[ObjectName](../../Objects/ObjectName/Table_ObjectName.md)`
+7. **Link to the frame's Table file** at the end of the description if one exists.
 
 ---
 
@@ -80,9 +128,11 @@ Include only when there are non-obvious constraints, ordering requirements, or c
 Before finalizing a frame description file, verify:
 
 - [ ] **Purpose** is 2–3 sentences and clearly states the frame's role
+- [ ] **Structure Overview** uses icons consistently and matches the Table file order
+- [ ] **Structure Overview** uses cardinality notation on every element — no "mandatory"/"optional" words
 - [ ] **Contained Elements** lists all key collections from the XML example
 - [ ] **Contained Elements** links to existing Object Table files where available
 - [ ] **Frame Relationships** describes dependencies upstream and downstream
 - [ ] **Usage Notes** (if present) provides actionable, non-obvious guidance
-- [ ] **No sections beyond the 4 defined here**
+- [ ] **No sections beyond the 5 defined here**
 - [ ] **All relative links** are functional

--- a/LLM/Templates/Frame_Description_Template.md
+++ b/LLM/Templates/Frame_Description_Template.md
@@ -1,0 +1,88 @@
+# `<FrameName>` — Description Template
+
+## Overview
+
+This template defines the structure for all Frame description files in the NeTEx profile.
+Frame descriptions are simpler than Object descriptions because Frames are containers that group
+related Objects rather than carrying rich domain data themselves.
+
+All description files must follow this 4-section format in the exact order specified below.
+
+---
+
+## Mandatory Section Order
+
+**Sections 1–3 are required. Section 4 is optional.**
+All sections must appear in this exact sequence.
+
+---
+
+## 1. Purpose
+
+**Required.** A short (2–3 sentence) explanation of the frame's role, scope, and what kind of data it contains.
+Should clarify where the frame sits in the NeTEx delivery structure (e.g., child of CompositeFrame).
+
+**Example:**
+> A **ServiceFrame** contains the network and route definitions for a public transport delivery. It groups Lines, Routes, JourneyPatterns, ScheduledStopPoints, and DestinationDisplays — the structural elements that describe where and how services run.
+
+---
+
+## 2. Contained Elements
+
+**Required.** A bulleted list of the key collections and elements carried by this frame.
+Each item should name the container element and briefly describe what it holds, with links to
+the relevant Object Table files where they exist.
+
+**Example:**
+- **lines** – Collection of [Line](../../Objects/Line/Table_Line.md) definitions
+- **routes** – Collection of [Route](../../Objects/Route/Table_Route.md) definitions
+- **journeyPatterns** – Collection of [JourneyPattern](../../Objects/JourneyPattern/Table_JourneyPattern.md) definitions
+- **scheduledStopPoints** – Collection of [ScheduledStopPoint](../../Objects/ScheduledStopPoint/Table_ScheduledStopPoint.md) definitions
+- **destinationDisplays** – Collection of [DestinationDisplay](../../Objects/DestinationDisplay/Table_DestinationDisplay.md) definitions
+
+---
+
+## 3. Frame Relationships
+
+**Required.** Describe how this frame relates to other frames in a typical NeTEx delivery.
+Include which frames it depends on and which frames depend on it.
+
+**Example:**
+> ServiceFrame depends on **ResourceFrame** for Operator and Authority definitions.
+> **TimetableFrame** depends on ServiceFrame for JourneyPatterns and Lines.
+> All frames are typically wrapped in a **CompositeFrame** within a PublicationDelivery.
+
+---
+
+## 4. Usage Notes (optional)
+
+**Optional.** Any additional guidance on how to use the frame correctly.
+Include only when there are non-obvious constraints, ordering requirements, or common mistakes.
+
+**Example:**
+> - The ServiceFrame must always appear after ResourceFrame in the CompositeFrame when Operators are referenced by Lines.
+> - A single delivery may contain multiple ServiceFrames if they cover different codespaces.
+
+---
+
+## Section Rules & Constraints
+
+1. **Sections 1–3 are mandatory.** All must be present and in order.
+2. **Section 4 is optional.** Omit if not relevant.
+3. **No additional top-level sections.** Keep frame descriptions concise.
+4. **Use relative markdown links** to reference Object Table files: `[ObjectName](../../Objects/ObjectName/Table_ObjectName.md)`
+5. **Link to the frame's Table file** at the end of the description if one exists.
+
+---
+
+## Quality Checklist
+
+Before finalizing a frame description file, verify:
+
+- [ ] **Purpose** is 2–3 sentences and clearly states the frame's role
+- [ ] **Contained Elements** lists all key collections from the XML example
+- [ ] **Contained Elements** links to existing Object Table files where available
+- [ ] **Frame Relationships** describes dependencies upstream and downstream
+- [ ] **Usage Notes** (if present) provides actionable, non-obvious guidance
+- [ ] **No sections beyond the 4 defined here**
+- [ ] **All relative links** are functional

--- a/LLM/Templates/Frame_Structure_and_Table_Template.md
+++ b/LLM/Templates/Frame_Structure_and_Table_Template.md
@@ -1,0 +1,64 @@
+## 1. Structure Overview (placed at the top of `Table_<FrameName>.md`)
+
+The Structure Overview must:
+- start with the frame name as the root node (e.g., `ServiceFrame`),
+- follow the exact element order from the XML examples,
+- show nesting using a monospace tree diagram,
+- use box-drawing symbols for clarity and consistency,
+- list attributes inline using `ElementName/@attribute`,
+- show cardinality on every element using standard notation: `(1..1)`, `(1..n)`, `(0..1)`, `(0..n)`,
+- match the Structure Overview in the corresponding `Description_<FrameName>.md` if one exists,
+- contain no descriptions or comments—structure only.
+
+### Structure Overview Template
+```text
+<FrameName>
+ ├─ @id (1..1)
+ ├─ @version (1..1)
+ ├─ <CollectionA> (0..1)
+ │   └─ <ChildObject> (0..n)
+ ├─ <CollectionB> (0..1)
+ │   └─ <ChildObject> (0..n)
+ └─ <CollectionC> (0..1)
+     └─ <ChildObject> (0..n)
+```
+
+## 2. `Table_<FrameName>.md` (mandatory)
+
+The flat table provides a normalized representation of the frame's structure.
+It must always be placed below the Structure Overview.
+
+### Required Columns
+
+The table must always contain the following columns, in this order:
+
+Element | Type | Description | Path
+
+### Rules
+- **Element** must contain only the element name or attribute (e.g., `organisations`, `Authority`).
+  No nesting or path notation is allowed here.
+
+- **Cross-references** to Objects must be written using relative links.
+  The link wraps the Object name and points to its Table file.
+  Example:
+  `[Authority](../../Objects/Authority/Table_Authority.md)`
+
+- **Type** must reflect the datatype or structural role:
+  - Use `Container` for collection elements (e.g., `organisations`, `vehicleJourneys`)
+  - Use `Element` for child objects within a collection
+  - Use `ID` and `String` for attributes
+  - Use `Reference` for `@ref` elements
+
+- **Description** must briefly describe the element's purpose within the frame.
+
+- **Path** must contain the full hierarchical structure using slash notation
+  (e.g., `ServiceFrame/lines/Line`).
+
+### Additional Requirements
+- All columns must be present for every row.
+- Attributes must appear with an `@` prefix.
+- The structure, order, and presence of elements must match the XML examples.
+- The table and Structure Overview must always remain synchronized.
+- All documentation must be written in English.
+- Frame tables do not use profile columns (unlike Object tables). Frames serve as
+  containers and their structure is consistent across profiles.


### PR DESCRIPTION
Create Frame_Description_Template.md (4-section: Purpose, Contained Elements, Frame Relationships, Usage Notes) and
Frame_Structure_and_Table_Template.md. Update LLM/README.md with links to both templates and mandatory Table file for frames.

Rewrite all 8 frame Description files to follow the new template and create Table files for: ResourceFrame, ServiceFrame, SiteFrame, TimetableFrame, ServiceCalendarFrame, FareFrame, VehicleScheduleFrame, and SalesTransactionFrame.