### PR TITLE
docs: Harmonize codespaces across XML examples (ENT->ERP, AKT/SJN->NP)

### DIFF
--- a/Frames/Example_PublicationDelivery.xml
+++ b/Frames/Example_PublicationDelivery.xml
@@ -5,18 +5,18 @@
   <PublicationTimestamp>2026-02-25T14:22:00Z</PublicationTimestamp>
   <ParticipantRef>EuPro</ParticipantRef>
   <dataObjects>
-    <CompositeFrame id="ENT:CompositeFrame:Example:1" version="1">
+    <CompositeFrame id="ERP:CompositeFrame:Example:1" version="1">
       <frames>
-        <ResourceFrame id="ENT:ResourceFrame:1" version="1">
+        <ResourceFrame id="ERP:ResourceFrame:1" version="1">
           <organisations>
-            <Operator id="ENT:Operator:OP_001:1" version="1">
+            <Operator id="ERP:Operator:OP_001:1" version="1">
               <Name>Example Operator</Name>
             </Operator>
           </organisations>
         </ResourceFrame>
-        <ServiceFrame id="ENT:ServiceFrame:1" version="1">
+        <ServiceFrame id="ERP:ServiceFrame:1" version="1">
           <journeyPatterns>
-            <JourneyPattern id="ENT:JourneyPattern:JP_001:1" version="1">
+            <JourneyPattern id="ERP:JourneyPattern:JP_001:1" version="1">
               <Name>Example JourneyPattern</Name>
             </JourneyPattern>
           </journeyPatterns>

--- a/Objects/AlternativeName/Example_AlternativeName_MIN.xml
+++ b/Objects/AlternativeName/Example_AlternativeName_MIN.xml
@@ -3,9 +3,9 @@
   <PublicationTimestamp>2026-03-12T10:30:00Z</PublicationTimestamp>
   <ParticipantRef>EuPro</ParticipantRef>
   <dataObjects>
-    <ResourceFrame id="ENT:ResourceFrame:AltName:1" version="1">
+    <ResourceFrame id="ERP:ResourceFrame:AltName:1" version="1">
       <organisations>
-        <Authority id="ENT:Authority:1" version="1">
+        <Authority id="ERP:Authority:1" version="1">
           <Name>Entur</Name>
           <alternativeNames>
             <AlternativeName>

--- a/Objects/AlternativeText/Example_AlternativeText_MIN.xml
+++ b/Objects/AlternativeText/Example_AlternativeText_MIN.xml
@@ -3,12 +3,12 @@
   <PublicationTimestamp>2026-03-12T11:05:00Z</PublicationTimestamp>
   <ParticipantRef>EuPro</ParticipantRef>
   <dataObjects>
-    <SiteFrame id="ENT:SiteFrame:AlternativeTextExample:1" version="1">
+    <SiteFrame id="ERP:SiteFrame:AlternativeTextExample:1" version="1">
       <alternativeTexts>
-        <AlternativeText id="ENT:AlternativeText:1" version="1">
+        <AlternativeText id="ERP:AlternativeText:1" version="1">
           <Text>Official description of the site frame.</Text>
         </AlternativeText>
-        <AlternativeText id="ENT:AlternativeText:2" version="1">
+        <AlternativeText id="ERP:AlternativeText:2" version="1">
           <Text>Marketing description for public display.</Text>
         </AlternativeText>
       </alternativeTexts>

--- a/Objects/Authority/Example_Authority_NP.xml
+++ b/Objects/Authority/Example_Authority_NP.xml
@@ -3,9 +3,9 @@
   <PublicationTimestamp>2026-03-17T12:00:00Z</PublicationTimestamp>
   <ParticipantRef>EuPro</ParticipantRef>
   <dataObjects>
-    <ResourceFrame id="AKT:ResourceFrame:authorities:1" version="1">
+    <ResourceFrame id="NP:ResourceFrame:authorities:1" version="1">
       <organisations>
-        <Authority id="AKT:Authority:AKT_ID" version="1">
+        <Authority id="NP:Authority:AKT_ID" version="1">
           <CompanyNumber>991776524</CompanyNumber>
           <Name>Agder Kollektivtrafikk AS</Name>
           <LegalName>AKT AS</LegalName>

--- a/Objects/Codespace/Example_Codespace.xml
+++ b/Objects/Codespace/Example_Codespace.xml
@@ -6,7 +6,7 @@
   <dataObjects>
     <CompositeFrame id="ERP:CompositeFrame:CF_1" version="1">
       <codespaces>
-        <Codespace id="ERP">
+        <Codespace id="erp">
           <Xmlns>ERP</Xmlns>
           <XmlnsUrl>http://www.someurl.org/ns/erp</XmlnsUrl>
         </Codespace>

--- a/Objects/DatedServiceJourney/Example_DatedServiceJourney_NP.xml
+++ b/Objects/DatedServiceJourney/Example_DatedServiceJourney_NP.xml
@@ -3,18 +3,32 @@
   <PublicationTimestamp>2026-03-17T12:00:00Z</PublicationTimestamp>
   <ParticipantRef>EuPro</ParticipantRef>
   <dataObjects>
-    <TimetableFrame id="SJN:TimetableFrame:dsj:1" version="1">
-      <vehicleJourneys>
-        <DatedServiceJourney id="SJN:DatedServiceJourney:21_2026-06-01" version="1">
-          <ServiceJourneyRef ref="SJN:ServiceJourney:21_F6" version="0"/>
-          <OperatingDayRef ref="SJN:OperatingDay:2026-06-01"/>
-        </DatedServiceJourney>
-        <DatedServiceJourney id="SJN:DatedServiceJourney:21_2026-06-01_replaced" version="1">
-          <ServiceAlteration>replaced</ServiceAlteration>
-          <ServiceJourneyRef ref="SJN:ServiceJourney:21_F6" version="0"/>
-          <OperatingDayRef ref="SJN:OperatingDay:2026-06-01"/>
-        </DatedServiceJourney>
-      </vehicleJourneys>
-    </TimetableFrame>
+    <CompositeFrame id="NP:CompositeFrame:dsj:1" version="1">
+      <frames>
+        <ServiceCalendarFrame id="NP:ServiceCalendarFrame:dsj:1" version="1">
+          <operatingDays>
+            <OperatingDay id="NP:OperatingDay:2026-06-01" version="1">
+              <CalendarDate>2026-06-01</CalendarDate>
+            </OperatingDay>
+          </operatingDays>
+        </ServiceCalendarFrame>
+        <TimetableFrame id="NP:TimetableFrame:dsj:1" version="1">
+          <vehicleJourneys>
+            <ServiceJourney id="NP:ServiceJourney:21_F6" version="0">
+              <Name>Line 21 weekday pattern</Name>
+            </ServiceJourney>
+            <DatedServiceJourney id="NP:DatedServiceJourney:21_2026-06-01" version="1">
+              <ServiceJourneyRef ref="NP:ServiceJourney:21_F6" version="0"/>
+              <OperatingDayRef ref="NP:OperatingDay:2026-06-01"/>
+            </DatedServiceJourney>
+            <DatedServiceJourney id="NP:DatedServiceJourney:21_2026-06-01_replaced" version="1">
+              <ServiceAlteration>replaced</ServiceAlteration>
+              <ServiceJourneyRef ref="NP:ServiceJourney:21_F6" version="0"/>
+              <OperatingDayRef ref="NP:OperatingDay:2026-06-01"/>
+            </DatedServiceJourney>
+          </vehicleJourneys>
+        </TimetableFrame>
+      </frames>
+    </CompositeFrame>
   </dataObjects>
 </PublicationDelivery>

--- a/Objects/DayType/Example_DayType_MIN.xml
+++ b/Objects/DayType/Example_DayType_MIN.xml
@@ -5,11 +5,11 @@
   <PublicationTimestamp>2026-02-25T14:22:00Z</PublicationTimestamp>
   <ParticipantRef>EuPro</ParticipantRef>
   <dataObjects>
-    <CompositeFrame id="ENT:CompositeFrame:DayTypeExample:1" version="1">
+    <CompositeFrame id="ERP:CompositeFrame:DayTypeExample:1" version="1">
       <frames>
-        <ServiceCalendarFrame id="ENT:ServiceCalendarFrame:1" version="1">
+        <ServiceCalendarFrame id="ERP:ServiceCalendarFrame:1" version="1">
           <dayTypes>
-            <DayType id="ENT:DayType:WEEKDAYS:1" version="1">
+            <DayType id="ERP:DayType:WEEKDAYS:1" version="1">
               <Name>Weekdays</Name>
             </DayType>
           </dayTypes>

--- a/Objects/DayType/Example_DayType_NP.xml
+++ b/Objects/DayType/Example_DayType_NP.xml
@@ -3,16 +3,16 @@
   <PublicationTimestamp>2026-03-17T12:00:00Z</PublicationTimestamp>
   <ParticipantRef>EuPro</ParticipantRef>
   <dataObjects>
-    <ServiceCalendarFrame id="AKT:ServiceCalendarFrame:dt:1" version="1">
+    <ServiceCalendarFrame id="NP:ServiceCalendarFrame:dt:1" version="1">
       <dayTypes>
-        <DayType id="AKT:DayType:160_1" version="1">
+        <DayType id="NP:DayType:160_1" version="1">
           <properties>
             <PropertyOfDay>
               <DaysOfWeek>Monday Tuesday Wednesday Thursday Friday</DaysOfWeek>
             </PropertyOfDay>
           </properties>
         </DayType>
-        <DayType id="AKT:DayType:164_1" version="1"/>
+        <DayType id="NP:DayType:164_1" version="1"/>
       </dayTypes>
     </ServiceCalendarFrame>
   </dataObjects>

--- a/Objects/DestinationDisplay/Example_DestinationDisplay_MIN.xml
+++ b/Objects/DestinationDisplay/Example_DestinationDisplay_MIN.xml
@@ -3,12 +3,12 @@
   <PublicationTimestamp>2026-03-12T11:20:00Z</PublicationTimestamp>
   <ParticipantRef>EuPro</ParticipantRef>
   <dataObjects>
-    <ServiceFrame id="ENT:ServiceFrame:DestinationDisplayExample:1" version="1">
+    <ServiceFrame id="ERP:ServiceFrame:DestinationDisplayExample:1" version="1">
       <destinationDisplays>
-        <DestinationDisplay id="ENT:DestinationDisplay:1" version="1">
+        <DestinationDisplay id="ERP:DestinationDisplay:1" version="1">
           <FrontText>Oslo S</FrontText>
         </DestinationDisplay>
-        <DestinationDisplay id="ENT:DestinationDisplay:2" version="1">
+        <DestinationDisplay id="ERP:DestinationDisplay:2" version="1">
           <FrontText>Bergen</FrontText>
         </DestinationDisplay>
       </destinationDisplays>

--- a/Objects/DestinationDisplay/Example_DestinationDisplay_NP.xml
+++ b/Objects/DestinationDisplay/Example_DestinationDisplay_NP.xml
@@ -3,9 +3,9 @@
   <PublicationTimestamp>2026-03-17T12:00:00Z</PublicationTimestamp>
   <ParticipantRef>EuPro</ParticipantRef>
   <dataObjects>
-    <ServiceFrame id="AKT:ServiceFrame:dd:1" version="1">
+    <ServiceFrame id="NP:ServiceFrame:dd:1" version="1">
       <destinationDisplays>
-        <DestinationDisplay id="AKT:DestinationDisplay:3950001_1" version="1">
+        <DestinationDisplay id="NP:DestinationDisplay:3950001_1" version="1">
           <Name>Kristiansand via Baneheitunnelen</Name>
           <SideText>Kristiansand via Baneheitunnelen</SideText>
           <FrontText>Kristiansand via Baneheitunnelen</FrontText>

--- a/Objects/FlexibleServiceProperties/Example_FlexibleServiceProperties_MIN.xml
+++ b/Objects/FlexibleServiceProperties/Example_FlexibleServiceProperties_MIN.xml
@@ -3,9 +3,9 @@
   <PublicationTimestamp>2026-03-12T12:58:00Z</PublicationTimestamp>
   <ParticipantRef>EuPro</ParticipantRef>
   <dataObjects>
-    <GeneralFrame id="ENT:GeneralFrame:FlexProps:1" version="1">
+    <GeneralFrame id="ERP:GeneralFrame:FlexProps:1" version="1">
       <members>
-        <FlexibleServiceProperties id="ENT:FlexibleServiceProperties:1" version="1">
+        <FlexibleServiceProperties id="ERP:FlexibleServiceProperties:1" version="1">
           <ValidBetween>
             <FromDate>2026-03-12T00:00:00Z</FromDate>
             <ToDate>2027-03-12T00:00:00Z</ToDate>

--- a/Objects/Interchange/Example_Interchange_MIN.xml
+++ b/Objects/Interchange/Example_Interchange_MIN.xml
@@ -3,21 +3,21 @@
   <PublicationTimestamp>2026-02-28T01:47:03Z</PublicationTimestamp>
   <ParticipantRef>EuPro</ParticipantRef>
   <dataObjects>
-    <CompositeFrame id="ENT:CompositeFrame:InterchangeDemo:1" version="1">
+    <CompositeFrame id="ERP:CompositeFrame:InterchangeDemo:1" version="1">
       <frames>
-        <TimetableFrame id="ENT:TimetableFrame:1" version="1">
+        <TimetableFrame id="ERP:TimetableFrame:1" version="1">
           <vehicleJourneys>
-            <ServiceJourney id="ENT:ServiceJourney:1001" version="1">
+            <ServiceJourney id="ERP:ServiceJourney:1001" version="1">
               <Name>Demo A</Name>
             </ServiceJourney>
-            <ServiceJourney id="ENT:ServiceJourney:1002" version="1">
+            <ServiceJourney id="ERP:ServiceJourney:1002" version="1">
               <Name>Demo B</Name>
             </ServiceJourney>
           </vehicleJourneys>
           <journeyInterchanges>
-            <ServiceJourneyInterchange id="ENT:ServiceJourneyInterchange:1001_to_1002" version="1">
-              <FromJourneyRef ref="ENT:ServiceJourney:1001"/>
-              <ToJourneyRef ref="ENT:ServiceJourney:1002"/>
+            <ServiceJourneyInterchange id="ERP:ServiceJourneyInterchange:1001_to_1002" version="1">
+              <FromJourneyRef ref="ERP:ServiceJourney:1001"/>
+              <ToJourneyRef ref="ERP:ServiceJourney:1002"/>
             </ServiceJourneyInterchange>
           </journeyInterchanges>
         </TimetableFrame>

--- a/Objects/Interchange/Example_Interchange_NP.xml
+++ b/Objects/Interchange/Example_Interchange_NP.xml
@@ -3,14 +3,14 @@
   <PublicationTimestamp>2026-03-17T12:00:00Z</PublicationTimestamp>
   <ParticipantRef>EuPro</ParticipantRef>
   <dataObjects>
-    <TimetableFrame id="AKT:TimetableFrame:ic:1" version="1">
+    <TimetableFrame id="NP:TimetableFrame:ic:1" version="1">
       <journeyInterchanges>
-        <ServiceJourneyInterchange id="AKT:ServiceJourneyInterchange:1330756_1_1" version="1">
+        <ServiceJourneyInterchange id="NP:ServiceJourneyInterchange:1330756_1_1" version="1">
           <Guaranteed>true</Guaranteed>
-          <FromPointRef ref="AKT:ScheduledStopPoint:9060006_1"/>
-          <ToPointRef ref="AKT:ScheduledStopPoint:9060006_1"/>
-          <FromJourneyRef ref="AKT:ServiceJourney:15044_371"/>
-          <ToJourneyRef ref="AKT:ServiceJourney:15045_372" version="1"/>
+          <FromPointRef ref="NP:ScheduledStopPoint:9060006_1"/>
+          <ToPointRef ref="NP:ScheduledStopPoint:9060006_1"/>
+          <FromJourneyRef ref="NP:ServiceJourney:15044_371"/>
+          <ToJourneyRef ref="NP:ServiceJourney:15045_372" version="1"/>
         </ServiceJourneyInterchange>
       </journeyInterchanges>
     </TimetableFrame>

--- a/Objects/JourneyPattern/Example_JourneyPattern_MIN.xml
+++ b/Objects/JourneyPattern/Example_JourneyPattern_MIN.xml
@@ -5,11 +5,11 @@
   <PublicationTimestamp>2026-02-25T14:22:00Z</PublicationTimestamp>
   <ParticipantRef>EuPro</ParticipantRef>
   <dataObjects>
-    <CompositeFrame id="ENT:CompositeFrame:JourneyPatternExample:1" version="1">
+    <CompositeFrame id="ERP:CompositeFrame:JourneyPatternExample:1" version="1">
       <frames>
-        <ServiceFrame id="ENT:ServiceFrame:1" version="1">
+        <ServiceFrame id="ERP:ServiceFrame:1" version="1">
           <journeyPatterns>
-            <JourneyPattern id="ENT:JourneyPattern:JP_001:1" version="1">
+            <JourneyPattern id="ERP:JourneyPattern:JP_001:1" version="1">
               <Name>Example JourneyPattern</Name>
             </JourneyPattern>
           </journeyPatterns>

--- a/Objects/JourneyPattern/Example_JourneyPattern_NP.xml
+++ b/Objects/JourneyPattern/Example_JourneyPattern_NP.xml
@@ -3,31 +3,31 @@
   <PublicationTimestamp>2026-03-17T12:00:00Z</PublicationTimestamp>
   <ParticipantRef>EuPro</ParticipantRef>
   <dataObjects>
-    <ServiceFrame id="AKT:ServiceFrame:jp:1" version="1">
+    <ServiceFrame id="NP:ServiceFrame:jp:1" version="1">
       <journeyPatterns>
-        <JourneyPattern id="AKT:JourneyPattern:81648_1" version="1">
+        <JourneyPattern id="NP:JourneyPattern:81648_1" version="1">
           <Name>Arendal bussterminal -&gt; Kristiansand rutebilstasjon</Name>
-          <RouteRef ref="AKT:Route:49747_1" version="1"/>
+          <RouteRef ref="NP:Route:49747_1" version="1"/>
           <pointsInSequence>
-            <StopPointInJourneyPattern order="1" version="1" id="AKT:StopPointInJourneyPattern:81648_1_1">
-              <ScheduledStopPointRef ref="AKT:ScheduledStopPoint:9060006_1"/>
+            <StopPointInJourneyPattern order="1" version="1" id="NP:StopPointInJourneyPattern:81648_1_1">
+              <ScheduledStopPointRef ref="NP:ScheduledStopPoint:9060006_1"/>
               <ForAlighting>false</ForAlighting>
-              <DestinationDisplayRef ref="AKT:DestinationDisplay:3950001_1"/>
+              <DestinationDisplayRef ref="NP:DestinationDisplay:3950001_1"/>
             </StopPointInJourneyPattern>
-            <StopPointInJourneyPattern order="2" version="1" id="AKT:StopPointInJourneyPattern:81648_2_1">
-              <ScheduledStopPointRef ref="AKT:ScheduledStopPoint:9060007_1"/>
+            <StopPointInJourneyPattern order="2" version="1" id="NP:StopPointInJourneyPattern:81648_2_1">
+              <ScheduledStopPointRef ref="NP:ScheduledStopPoint:9060007_1"/>
             </StopPointInJourneyPattern>
-            <StopPointInJourneyPattern order="3" version="1" id="AKT:StopPointInJourneyPattern:81648_3_1">
-              <ScheduledStopPointRef ref="AKT:ScheduledStopPoint:10013457_1"/>
+            <StopPointInJourneyPattern order="3" version="1" id="NP:StopPointInJourneyPattern:81648_3_1">
+              <ScheduledStopPointRef ref="NP:ScheduledStopPoint:10013457_1"/>
               <ForBoarding>false</ForBoarding>
             </StopPointInJourneyPattern>
           </pointsInSequence>
           <linksInSequence>
-            <ServiceLinkInJourneyPattern order="1" version="1" id="AKT:ServiceLinkInJourneyPattern:3556197">
-              <ServiceLinkRef ref="AKT:ServiceLink:2645_1"/>
+            <ServiceLinkInJourneyPattern order="1" version="1" id="NP:ServiceLinkInJourneyPattern:3556197">
+              <ServiceLinkRef ref="NP:ServiceLink:2645_1"/>
             </ServiceLinkInJourneyPattern>
-            <ServiceLinkInJourneyPattern order="2" version="1" id="AKT:ServiceLinkInJourneyPattern:3556198">
-              <ServiceLinkRef ref="AKT:ServiceLink:2646_1"/>
+            <ServiceLinkInJourneyPattern order="2" version="1" id="NP:ServiceLinkInJourneyPattern:3556198">
+              <ServiceLinkRef ref="NP:ServiceLink:2646_1"/>
             </ServiceLinkInJourneyPattern>
           </linksInSequence>
         </JourneyPattern>

--- a/Objects/Line/Example_Line_NP.xml
+++ b/Objects/Line/Example_Line_NP.xml
@@ -3,9 +3,9 @@
   <PublicationTimestamp>2026-03-17T12:00:00Z</PublicationTimestamp>
   <ParticipantRef>EuPro</ParticipantRef>
   <dataObjects>
-    <ServiceFrame id="AKT:ServiceFrame:lines:1" version="1">
+    <ServiceFrame id="NP:ServiceFrame:lines:1" version="1">
       <lines>
-        <Line id="AKT:Line:100" version="1">
+        <Line id="NP:Line:100" version="1">
           <Name>Arendal-Kristiansand</Name>
           <TransportMode>bus</TransportMode>
           <TransportSubmode>
@@ -13,8 +13,8 @@
           </TransportSubmode>
           <PublicCode>100</PublicCode>
           <PrivateCode>100</PrivateCode>
-          <OperatorRef ref="AKT:Operator:923"/>
-          <RepresentedByGroupRef ref="AKT:Network:AKTNett"/>
+          <OperatorRef ref="NP:Operator:923"/>
+          <RepresentedByGroupRef ref="NP:Network:AKTNett"/>
           <Presentation>
             <Colour>000000</Colour>
             <TextColour>FFFF00</TextColour>

--- a/Objects/Notice/Example_Notice_NP.xml
+++ b/Objects/Notice/Example_Notice_NP.xml
@@ -3,12 +3,12 @@
   <PublicationTimestamp>2026-03-17T12:00:00Z</PublicationTimestamp>
   <ParticipantRef>EuPro</ParticipantRef>
   <dataObjects>
-    <ServiceFrame id="AKT:ServiceFrame:notices:1" version="1">
+    <ServiceFrame id="NP:ServiceFrame:notices:1" version="1">
       <notices>
-        <Notice id="AKT:Notice:39" version="1">
+        <Notice id="NP:Notice:39" version="1">
           <Text>Bestillingstur, tlf 91600528 senest 30min. for avgang.</Text>
         </Notice>
-        <Notice id="AKT:Notice:20" version="1">
+        <Notice id="NP:Notice:20" version="1">
           <Text>Går ikke i skolens ferie- og fridager</Text>
         </Notice>
       </notices>

--- a/Objects/Operator/Example_Operator_NP.xml
+++ b/Objects/Operator/Example_Operator_NP.xml
@@ -3,9 +3,9 @@
   <PublicationTimestamp>2026-03-17T12:00:00Z</PublicationTimestamp>
   <ParticipantRef>EuPro</ParticipantRef>
   <dataObjects>
-    <ResourceFrame id="AKT:ResourceFrame:operators:1" version="1">
+    <ResourceFrame id="NP:ResourceFrame:operators:1" version="1">
       <organisations>
-        <Operator id="AKT:Operator:331" version="1">
+        <Operator id="NP:Operator:331" version="1">
           <CompanyNumber>974208849</CompanyNumber>
           <Name>Boreal Sjø</Name>
           <LegalName>Boreal Sjø AS</LegalName>

--- a/Objects/Parking/Example_Parking_MIN.xml
+++ b/Objects/Parking/Example_Parking_MIN.xml
@@ -3,9 +3,9 @@
   <PublicationTimestamp>2026-03-12T13:18:00Z</PublicationTimestamp>
   <ParticipantRef>EuPro</ParticipantRef>
   <dataObjects>
-    <SiteFrame id="ENT:SiteFrame:ParkingExample:1" version="1">
+    <SiteFrame id="ERP:SiteFrame:ParkingExample:1" version="1">
       <parkings>
-        <Parking id="ENT:Parking:1" version="1">
+        <Parking id="ERP:Parking:1" version="1">
           <Name>Park and Ride Example</Name>
           <ParkingType>parkAndRide</ParkingType>
         </Parking>

--- a/Objects/PassengerStopAssignment/Example_PassengerStopAssignment_NP.xml
+++ b/Objects/PassengerStopAssignment/Example_PassengerStopAssignment_NP.xml
@@ -12,8 +12,8 @@
           <ScheduledStopPointRef ref="NSR:ScheduledStopPoint:S59977" versionRef="1"/>
           <StopPlaceRef ref="NSR:StopPlace:59977" version="1"/>
         </PassengerStopAssignment>
-        <PassengerStopAssignment order="2" version="1" id="AKT:PassengerStopAssignment:10176612_1">
-          <ScheduledStopPointRef ref="AKT:ScheduledStopPoint:10176612_1" version="1"/>
+        <PassengerStopAssignment order="2" version="1" id="NP:PassengerStopAssignment:10176612_1">
+          <ScheduledStopPointRef ref="NP:ScheduledStopPoint:10176612_1" version="1"/>
           <QuayRef ref="NSR:Quay:43750"/>
         </PassengerStopAssignment>
       </stopAssignments>

--- a/Objects/PurposeOfGrouping/Example_PurposeOfGrouping_MIN.xml
+++ b/Objects/PurposeOfGrouping/Example_PurposeOfGrouping_MIN.xml
@@ -3,9 +3,9 @@
   <PublicationTimestamp>2026-03-12T13:25:00Z</PublicationTimestamp>
   <ParticipantRef>EuPro</ParticipantRef>
   <dataObjects>
-    <ResourceFrame id="ENT:ResourceFrame:PurposeOfGroupingExample:1" version="1">
+    <ResourceFrame id="ERP:ResourceFrame:PurposeOfGroupingExample:1" version="1">
       <typesOfValue>
-        <PurposeOfGrouping id="ENT:PurposeOfGrouping:1" version="1">
+        <PurposeOfGrouping id="ERP:PurposeOfGrouping:1" version="1">
           <Name>Marketing grouping</Name>
         </PurposeOfGrouping>
       </typesOfValue>

--- a/Objects/Quay/Example_Quay_NP.xml
+++ b/Objects/Quay/Example_Quay_NP.xml
@@ -12,7 +12,7 @@
               <keyList>
                 <KeyValue>
                   <Key>imported-id</Key>
-                  <Value>AKT:Quay:9060006_1</Value>
+                  <Value>NP:Quay:9060006_1</Value>
                 </KeyValue>
               </keyList>
               <Name lang="nor">Spor 1</Name>

--- a/Objects/Route/Example_Route_NP.xml
+++ b/Objects/Route/Example_Route_NP.xml
@@ -3,19 +3,19 @@
   <PublicationTimestamp>2026-03-17T12:00:00Z</PublicationTimestamp>
   <ParticipantRef>EuPro</ParticipantRef>
   <dataObjects>
-    <ServiceFrame id="AKT:ServiceFrame:routes:1" version="1">
+    <ServiceFrame id="NP:ServiceFrame:routes:1" version="1">
       <routes>
-        <Route id="AKT:Route:49747_1" version="1">
+        <Route id="NP:Route:49747_1" version="1">
           <Name>Arendal bussterminal -&gt; Kristiansand rutebilstasjon</Name>
           <ShortName>Arendal -&gt; Kristiansand</ShortName>
-          <LineRef ref="AKT:Line:100" version="1"/>
+          <LineRef ref="NP:Line:100" version="1"/>
           <DirectionType>outbound</DirectionType>
           <pointsInSequence>
-            <PointOnRoute order="1" version="1" id="AKT:PointOnRoute:3555907">
-              <RoutePointRef ref="AKT:RoutePoint:9060006_1"/>
+            <PointOnRoute order="1" version="1" id="NP:PointOnRoute:3555907">
+              <RoutePointRef ref="NP:RoutePoint:9060006_1"/>
             </PointOnRoute>
-            <PointOnRoute order="2" version="1" id="AKT:PointOnRoute:3555908">
-              <RoutePointRef ref="AKT:RoutePoint:10013457_1"/>
+            <PointOnRoute order="2" version="1" id="NP:PointOnRoute:3555908">
+              <RoutePointRef ref="NP:RoutePoint:10013457_1"/>
             </PointOnRoute>
           </pointsInSequence>
         </Route>

--- a/Objects/SanitaryEquipment/Example_SanitaryEquipment_MIN.xml
+++ b/Objects/SanitaryEquipment/Example_SanitaryEquipment_MIN.xml
@@ -3,9 +3,9 @@
   <PublicationTimestamp>2026-03-12T13:35:00Z</PublicationTimestamp>
   <ParticipantRef>EuPro</ParticipantRef>
   <dataObjects>
-    <GeneralFrame id="ENT:GeneralFrame:SanitaryEquipmentExample:1" version="1">
+    <GeneralFrame id="ERP:GeneralFrame:SanitaryEquipmentExample:1" version="1">
       <members>
-        <SanitaryEquipment id="ENT:SanitaryEquipment:1" version="1">
+        <SanitaryEquipment id="ERP:SanitaryEquipment:1" version="1">
           <ValidBetween>
             <FromDate>2026-03-12T00:00:00Z</FromDate>
             <ToDate>2027-03-12T00:00:00Z</ToDate>

--- a/Objects/ScheduledStopPoint/Example_ScheduledStopPoint_NP.xml
+++ b/Objects/ScheduledStopPoint/Example_ScheduledStopPoint_NP.xml
@@ -11,7 +11,7 @@
           </ValidBetween>
           <Name>Oslo S</Name>
         </ScheduledStopPoint>
-        <ScheduledStopPoint id="AKT:ScheduledStopPoint:9060006_1" version="1"/>
+        <ScheduledStopPoint id="NP:ScheduledStopPoint:9060006_1" version="1"/>
       </scheduledStopPoints>
     </ServiceFrame>
   </dataObjects>

--- a/Objects/ServiceJourney/Example_ServiceJourney_MIN.xml
+++ b/Objects/ServiceJourney/Example_ServiceJourney_MIN.xml
@@ -5,11 +5,11 @@
     <PublicationTimestamp>2026-02-25T14:22:00Z</PublicationTimestamp>
     <ParticipantRef>EuPro</ParticipantRef>
     <dataObjects>
-        <CompositeFrame id="ENT:CompositeFrame:ServiceJourneyExample:1" version="1">
+        <CompositeFrame id="ERP:CompositeFrame:ServiceJourneyExample:1" version="1">
             <frames>
-                <TimetableFrame id="ENT:TimetableFrame:1" version="1">
+                <TimetableFrame id="ERP:TimetableFrame:1" version="1">
                     <vehicleJourneys>
-                        <ServiceJourney id="ENT:ServiceJourney:SJ_001:1" version="1" responsibilitySetRef="ERP:ResponsibilitySet:Test">
+                        <ServiceJourney id="ERP:ServiceJourney:SJ_001:1" version="1" responsibilitySetRef="ERP:ResponsibilitySet:Test">
                             <Name>Example ServiceJourney</Name>
                         </ServiceJourney>
                     </vehicleJourneys>

--- a/Objects/ServiceJourney/Example_ServiceJourney_NP.xml
+++ b/Objects/ServiceJourney/Example_ServiceJourney_NP.xml
@@ -3,29 +3,29 @@
   <PublicationTimestamp>2026-03-17T12:00:00Z</PublicationTimestamp>
   <ParticipantRef>EuPro</ParticipantRef>
   <dataObjects>
-    <TimetableFrame id="AKT:TimetableFrame:sj:1" version="1">
+    <TimetableFrame id="NP:TimetableFrame:sj:1" version="1">
       <vehicleJourneys>
-        <ServiceJourney id="AKT:ServiceJourney:15044_371" version="1">
+        <ServiceJourney id="NP:ServiceJourney:15044_371" version="1">
           <Name>Arendal bussterminal -&gt; Kristiansand rutebilstasjon</Name>
           <PrivateCode>371</PrivateCode>
           <dayTypes>
-            <DayTypeRef ref="AKT:DayType:9_1"/>
+            <DayTypeRef ref="NP:DayType:9_1"/>
           </dayTypes>
-          <JourneyPatternRef ref="AKT:JourneyPattern:81648_1" version="1"/>
-          <OperatorRef ref="AKT:Operator:923"/>
-          <LineRef ref="AKT:Line:100" version="1"/>
+          <JourneyPatternRef ref="NP:JourneyPattern:81648_1" version="1"/>
+          <OperatorRef ref="NP:Operator:923"/>
+          <LineRef ref="NP:Line:100" version="1"/>
           <passingTimes>
-            <TimetabledPassingTime version="1" id="AKT:TimetabledPassingTime:1001">
-              <StopPointInJourneyPatternRef ref="AKT:StopPointInJourneyPattern:81648_1_1" version="1"/>
+            <TimetabledPassingTime version="1" id="NP:TimetabledPassingTime:1001">
+              <StopPointInJourneyPatternRef ref="NP:StopPointInJourneyPattern:81648_1_1" version="1"/>
               <DepartureTime>08:30:00</DepartureTime>
             </TimetabledPassingTime>
-            <TimetabledPassingTime version="1" id="AKT:TimetabledPassingTime:1002">
-              <StopPointInJourneyPatternRef ref="AKT:StopPointInJourneyPattern:81648_2_1" version="1"/>
+            <TimetabledPassingTime version="1" id="NP:TimetabledPassingTime:1002">
+              <StopPointInJourneyPatternRef ref="NP:StopPointInJourneyPattern:81648_2_1" version="1"/>
               <ArrivalTime>09:15:00</ArrivalTime>
               <DepartureTime>09:17:00</DepartureTime>
             </TimetabledPassingTime>
-            <TimetabledPassingTime version="1" id="AKT:TimetabledPassingTime:1003">
-              <StopPointInJourneyPatternRef ref="AKT:StopPointInJourneyPattern:81648_3_1" version="1"/>
+            <TimetabledPassingTime version="1" id="NP:TimetabledPassingTime:1003">
+              <StopPointInJourneyPatternRef ref="NP:StopPointInJourneyPattern:81648_3_1" version="1"/>
               <ArrivalTime>10:00:00</ArrivalTime>
             </TimetabledPassingTime>
           </passingTimes>

--- a/Objects/ShelterEquipment/Example_ShelterEquipment_MIN.xml
+++ b/Objects/ShelterEquipment/Example_ShelterEquipment_MIN.xml
@@ -3,9 +3,9 @@
   <PublicationTimestamp>2026-03-12T13:45:00Z</PublicationTimestamp>
   <ParticipantRef>EuPro</ParticipantRef>
   <dataObjects>
-    <GeneralFrame id="ENT:GeneralFrame:ShelterEquipmentExample:1" version="1">
+    <GeneralFrame id="ERP:GeneralFrame:ShelterEquipmentExample:1" version="1">
       <members>
-        <ShelterEquipment id="ENT:ShelterEquipment:1" version="1">
+        <ShelterEquipment id="ERP:ShelterEquipment:1" version="1">
           <ValidBetween>
             <FromDate>2026-03-12T00:00:00Z</FromDate>
             <ToDate>2027-03-12T00:00:00Z</ToDate>

--- a/Objects/StopPlace/Example_StopPlace_NP.xml
+++ b/Objects/StopPlace/Example_StopPlace_NP.xml
@@ -9,7 +9,7 @@
           <keyList>
             <KeyValue>
               <Key>imported-id</Key>
-              <Value>AKT:StopArea:9060006</Value>
+              <Value>NP:StopArea:9060006</Value>
             </KeyValue>
           </keyList>
           <Name lang="nor">Oslo S</Name>

--- a/Objects/TariffZone/Example_TariffZone_MIN.xml
+++ b/Objects/TariffZone/Example_TariffZone_MIN.xml
@@ -3,9 +3,9 @@
   <PublicationTimestamp>2026-03-12T13:55:00Z</PublicationTimestamp>
   <ParticipantRef>EuPro</ParticipantRef>
   <dataObjects>
-    <ResourceFrame id="ENT:ResourceFrame:TariffZoneExample:1" version="1">
+    <ResourceFrame id="ERP:ResourceFrame:TariffZoneExample:1" version="1">
       <zones>
-        <TariffZone id="ENT:TariffZone:1" version="1">
+        <TariffZone id="ERP:TariffZone:1" version="1">
           <Name>Zone A</Name>
         </TariffZone>
       </zones>

--- a/Objects/TicketingEquipment/Example_TicketingEquipment_MIN.xml
+++ b/Objects/TicketingEquipment/Example_TicketingEquipment_MIN.xml
@@ -3,9 +3,9 @@
   <PublicationTimestamp>2026-03-12T14:00:00Z</PublicationTimestamp>
   <ParticipantRef>EuPro</ParticipantRef>
   <dataObjects>
-    <GeneralFrame id="ENT:GeneralFrame:TicketingEquipmentExample:1" version="1">
+    <GeneralFrame id="ERP:GeneralFrame:TicketingEquipmentExample:1" version="1">
       <members>
-        <TicketingEquipment id="ENT:TicketingEquipment:1" version="1">
+        <TicketingEquipment id="ERP:TicketingEquipment:1" version="1">
           <ValidBetween>
             <FromDate>2026-03-12T00:00:00Z</FromDate>
             <ToDate>2027-03-12T00:00:00Z</ToDate>

--- a/Objects/TopographicPlace/Example_TopographicPlace_MIN.xml
+++ b/Objects/TopographicPlace/Example_TopographicPlace_MIN.xml
@@ -3,9 +3,9 @@
   <PublicationTimestamp>2026-03-12T15:05:00Z</PublicationTimestamp>
   <ParticipantRef>EuPro</ParticipantRef>
   <dataObjects>
-    <SiteFrame id="ENT:SiteFrame:TopographicPlaceExample:1" version="1">
+    <SiteFrame id="ERP:SiteFrame:TopographicPlaceExample:1" version="1">
       <topographicPlaces>
-        <TopographicPlace id="ENT:TopographicPlace:Oslo:1" version="1">
+        <TopographicPlace id="ERP:TopographicPlace:Oslo:1" version="1">
           <Descriptor>
             <Name>Oslo</Name>
             <ShortName>Oslo</ShortName>

--- a/Objects/WaitingRoomEquipment/Example_WaitingRoomEquipment_MIN.xml
+++ b/Objects/WaitingRoomEquipment/Example_WaitingRoomEquipment_MIN.xml
@@ -3,9 +3,9 @@
   <PublicationTimestamp>2026-03-12T15:25:00Z</PublicationTimestamp>
   <ParticipantRef>EuPro</ParticipantRef>
   <dataObjects>
-    <GeneralFrame id="ENT:GeneralFrame:WaitingRoomEquipmentExample:1" version="1">
+    <GeneralFrame id="ERP:GeneralFrame:WaitingRoomEquipmentExample:1" version="1">
       <members>
-        <WaitingRoomEquipment id="ENT:WaitingRoomEquipment:1" version="1">
+        <WaitingRoomEquipment id="ERP:WaitingRoomEquipment:1" version="1">
           <ValidBetween>
             <FromDate>2026-03-12T00:00:00Z</FromDate>
             <ToDate>2027-03-12T00:00:00Z</ToDate>


### PR DESCRIPTION
Standardize codespace prefixes so all examples form unified profile deliveries: MIN examples use ERP, NP examples use NP (preserving NSR for Norwegian StopPlace Registry references). Also fixes DatedServiceJourney_NP validation by adding CompositeFrame wrapper with referenced ServiceJourney and OperatingDay.