### PR TITLE
fix: Remove version attr from external Ref elements to fix keyref val…

### DIFF
--- a/Objects/Interchange/Example_Interchange_NP.xml
+++ b/Objects/Interchange/Example_Interchange_NP.xml
@@ -10,7 +10,7 @@
           <FromPointRef ref="NP:ScheduledStopPoint:9060006_1"/>
           <ToPointRef ref="NP:ScheduledStopPoint:9060006_1"/>
           <FromJourneyRef ref="NP:ServiceJourney:15044_371"/>
-          <ToJourneyRef ref="NP:ServiceJourney:15045_372" version="1"/>
+          <ToJourneyRef ref="NP:ServiceJourney:15045_372"/>
         </ServiceJourneyInterchange>
       </journeyInterchanges>
     </TimetableFrame>

--- a/Objects/JourneyPattern/Example_JourneyPattern_NP.xml
+++ b/Objects/JourneyPattern/Example_JourneyPattern_NP.xml
@@ -7,7 +7,7 @@
       <journeyPatterns>
         <JourneyPattern id="NP:JourneyPattern:81648_1" version="1">
           <Name>Arendal bussterminal -&gt; Kristiansand rutebilstasjon</Name>
-          <RouteRef ref="NP:Route:49747_1" version="1"/>
+          <RouteRef ref="NP:Route:49747_1"/>
           <pointsInSequence>
             <StopPointInJourneyPattern order="1" version="1" id="NP:StopPointInJourneyPattern:81648_1_1">
               <ScheduledStopPointRef ref="NP:ScheduledStopPoint:9060006_1"/>

--- a/Objects/PassengerStopAssignment/Example_PassengerStopAssignment_NP.xml
+++ b/Objects/PassengerStopAssignment/Example_PassengerStopAssignment_NP.xml
@@ -10,10 +10,10 @@
             <FromDate>2026-01-15T10:22:00.000</FromDate>
           </ValidBetween>
           <ScheduledStopPointRef ref="NSR:ScheduledStopPoint:S59977" versionRef="1"/>
-          <StopPlaceRef ref="NSR:StopPlace:59977" version="1"/>
+          <StopPlaceRef ref="NSR:StopPlace:59977"/>
         </PassengerStopAssignment>
         <PassengerStopAssignment order="2" version="1" id="NP:PassengerStopAssignment:10176612_1">
-          <ScheduledStopPointRef ref="NP:ScheduledStopPoint:10176612_1" version="1"/>
+          <ScheduledStopPointRef ref="NP:ScheduledStopPoint:10176612_1"/>
           <QuayRef ref="NSR:Quay:43750"/>
         </PassengerStopAssignment>
       </stopAssignments>

--- a/Objects/Route/Example_Route_MIN.xml
+++ b/Objects/Route/Example_Route_MIN.xml
@@ -5,17 +5,17 @@
   <ShortName>10</ShortName>
   <PublicCode>10</PublicCode>
   <Description>Eksempelrute for linje 10, retning utgående</Description>
-  <LineRef ref="ERP:Line:LIN_10" version="1"/>
+  <LineRef ref="ERP:Line:LIN_10"/>
   <DirectionType>outbound</DirectionType>
   <PointsInSequence>
     <PointOnRoute id="ERP:PointOnRoute:POR_10_1" version="1" order="1">
-      <ScheduledStopPointRef ref="ERP:ScheduledStopPoint:SSP_1001" version="1"/>
+      <ScheduledStopPointRef ref="ERP:ScheduledStopPoint:SSP_1001"/>
     </PointOnRoute>
     <PointOnRoute id="ERP:PointOnRoute:POR_10_2" version="1" order="2">
-      <ScheduledStopPointRef ref="ERP:ScheduledStopPoint:SSP_1002" version="1"/>
+      <ScheduledStopPointRef ref="ERP:ScheduledStopPoint:SSP_1002"/>
     </PointOnRoute>
     <PointOnRoute id="ERP:PointOnRoute:POR_10_3" version="1" order="3">
-      <ScheduledStopPointRef ref="ERP:ScheduledStopPoint:SSP_1003" version="1"/>
+      <ScheduledStopPointRef ref="ERP:ScheduledStopPoint:SSP_1003"/>
     </PointOnRoute>
   </PointsInSequence>
 </Route>

--- a/Objects/Route/Example_Route_NP.xml
+++ b/Objects/Route/Example_Route_NP.xml
@@ -8,7 +8,7 @@
         <Route id="NP:Route:49747_1" version="1">
           <Name>Arendal bussterminal -&gt; Kristiansand rutebilstasjon</Name>
           <ShortName>Arendal -&gt; Kristiansand</ShortName>
-          <LineRef ref="NP:Line:100" version="1"/>
+          <LineRef ref="NP:Line:100"/>
           <DirectionType>outbound</DirectionType>
           <pointsInSequence>
             <PointOnRoute order="1" version="1" id="NP:PointOnRoute:3555907">

--- a/Objects/ServiceJourney/Example_ServiceJourney_NP.xml
+++ b/Objects/ServiceJourney/Example_ServiceJourney_NP.xml
@@ -11,21 +11,21 @@
           <dayTypes>
             <DayTypeRef ref="NP:DayType:9_1"/>
           </dayTypes>
-          <JourneyPatternRef ref="NP:JourneyPattern:81648_1" version="1"/>
+          <JourneyPatternRef ref="NP:JourneyPattern:81648_1"/>
           <OperatorRef ref="NP:Operator:923"/>
-          <LineRef ref="NP:Line:100" version="1"/>
+          <LineRef ref="NP:Line:100"/>
           <passingTimes>
             <TimetabledPassingTime version="1" id="NP:TimetabledPassingTime:1001">
-              <StopPointInJourneyPatternRef ref="NP:StopPointInJourneyPattern:81648_1_1" version="1"/>
+              <StopPointInJourneyPatternRef ref="NP:StopPointInJourneyPattern:81648_1_1"/>
               <DepartureTime>08:30:00</DepartureTime>
             </TimetabledPassingTime>
             <TimetabledPassingTime version="1" id="NP:TimetabledPassingTime:1002">
-              <StopPointInJourneyPatternRef ref="NP:StopPointInJourneyPattern:81648_2_1" version="1"/>
+              <StopPointInJourneyPatternRef ref="NP:StopPointInJourneyPattern:81648_2_1"/>
               <ArrivalTime>09:15:00</ArrivalTime>
               <DepartureTime>09:17:00</DepartureTime>
             </TimetabledPassingTime>
             <TimetabledPassingTime version="1" id="NP:TimetabledPassingTime:1003">
-              <StopPointInJourneyPatternRef ref="NP:StopPointInJourneyPattern:81648_3_1" version="1"/>
+              <StopPointInJourneyPatternRef ref="NP:StopPointInJourneyPattern:81648_3_1"/>
               <ArrivalTime>10:00:00</ArrivalTime>
             </TimetabledPassingTime>
           </passingTimes>

--- a/Objects/StopPlace/Example_StopPlace_NP.xml
+++ b/Objects/StopPlace/Example_StopPlace_NP.xml
@@ -31,7 +31,7 @@
               </AccessibilityLimitation>
             </limitations>
           </AccessibilityAssessment>
-          <TopographicPlaceRef ref="NSR:TopographicPlace:Oslo" version="1"/>
+          <TopographicPlaceRef ref="NSR:TopographicPlace:Oslo"/>
           <TransportMode>rail</TransportMode>
           <StopPlaceType>railStation</StopPlaceType>
           <Weighting>interchangeAllowed</Weighting>

--- a/Objects/TopographicPlace/Example_TopographicPlace_NP.xml
+++ b/Objects/TopographicPlace/Example_TopographicPlace_NP.xml
@@ -14,7 +14,7 @@
           </Descriptor>
           <TopographicPlaceType>municipality</TopographicPlaceType>
           <CountryRef ref="no"/>
-          <ParentTopographicPlaceRef ref="NSR:TopographicPlace:Oslo_county" version="1"/>
+          <ParentTopographicPlaceRef ref="NSR:TopographicPlace:Oslo_county"/>
           <IsoCode>0301</IsoCode>
         </TopographicPlace>
       </topographicPlaces>


### PR DESCRIPTION
…idation

Versioned refs (e.g. version="1") on *Ref elements trigger NeTEx schema keyref validation requiring the referenced object to exist in the same file. Removed version from 15 external refs across 7 files.