### PR TITLE
docs: Rewrite README.md to reflect current repository state

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,43 +1,96 @@
-
+<!-- LLM AGENT: Use LLM/README.md as startingpoint  -->
 # NeTEx Profile Documentation
+
 A practical reference, learning resource, and example library for working with NeTEx.
 
-This repository is designed as a human-friendly entry point to NeTEx: a place to learn the structure of the standard, explore real examples, and understand how frames and objects relate to each other in practice.
+This repository is a human-friendly entry point to NeTEx: a place to learn the structure of the standard, explore real examples, and understand how frames and objects relate to each other in practice.
 
-Its goals are:
-- 📘 **Introduce** the concepts and structure of NeTEx
-- 🧭 **Guide** readers through frames, objects, and modeling patterns
-- 🗂️ **Provide** a high-quality example library
-- 🛠️ **Define** conventions for profiling and documentation
-- 🔎 **Serve** as a reference for navigation and discovery
+- 📘 **Learn** the concepts and structure of NeTEx
+- 🧭 **Navigate** frames, objects, and modeling patterns
+- 🗂️ **Explore** a high-quality example library validated against the official XSD
+- 🔎 **Reference** element ordering, cardinality, and profile-specific requirements
+
+---
+
+## 📚 How to Use This Repository
+
+### Start here
+
+| Step | Where | What you'll find |
+|------|-------|-----------------|
+| 1 | [`Guides/`](Guides/) | Conceptual overviews, conventions, and getting started material |
+| 2 | [`Frames/`](Frames/) | How data is organized — each Frame groups related objects |
+| 3 | [`Objects/`](Objects/) | Detailed reference for every NeTEx object with examples |
+
+### Quick lookup
+
+- 📋 [**Table of Contents**](LLM/Tables/TableOfContent.md) — Complete index of all Guides, Frames, and Objects
+- 📄 [**Table of Examples**](LLM/Tables/TableOfExamples.md) — Every XML example with links and descriptions
 
 ---
 
 ## 🎯 What This Repository Contains
 
-### 1. **High‑quality NeTEx examples**
-Each example is:
-- Minimal, but complete enough to be meaningful
-- Structured consistently using the ERP codespace
+### 1. **Validated NeTEx examples**
+Every XML example is:
+- Validated against the [NeTEx 2.0 XSD schema](XSD%202.0/xsd/)
 - Designed to illustrate a single concept or object clearly
-- Built using a unified pattern:
+- Available in multiple profiles (see [Profiles](#-profiles) below)
+- Built using the standard NeTEx delivery pattern:
+
+```xml
+PublicationDelivery → dataObjects → Frame → …
+```
+
+### 2. **Structured documentation per object**
+For every frame and object, you will find three files:
+
+| File | Purpose |
+|------|---------|
+| `Description_<Name>.md` | Purpose, structure overview, key elements, and relationships |
+| `Table_<Name>.md` | Element-level specification with types, cardinality per profile, and XSD paths |
+| `Example_<Name>_<Profile>.xml` | One or more validated XML examples |
+
+### 3. **Guides**
+Each guide lives in its own folder under [`Guides/`](Guides/) and can include supporting files (diagrams, XML snippets, etc.):
+
+| Guide | Description |
+|-------|-------------|
+| [GetStarted](Guides/GetStarted/) | Minimal steps to begin working with the profile |
+| [FramesOverview](Guides/FramesOverview/) | Purpose and relationships of the various Frames |
+| [NeTExConventions](Guides/NeTExConventions/) | Casing rules, naming patterns, and a minimal example |
+| [SeparationOfConcerns](Guides/SeparationOfConcerns/) | Responsibilities and boundaries between components |
+| [Validation](Guides/Validation/) | How to validate NeTEx XML against schemas and rules |
+| [InterchangeOnly](Guides/InterchangeOnly/) | Scope and constraints of the Interchange-only profile |
+| [Glossary](Guides/Glossary/) | Terminology and definitions |
+
+---
+
+## 🏷️ Profiles
+
+This repository documents three profiles, each representing a different level of detail:
+
+| Profile | Code | Codespace | Description |
+|---------|------|-----------|-------------|
+| **Minimum** | `MIN` | `ERP` | Bare minimum elements required |
+| **European Recommended** | `ERP` | `ERP` | Full European recommended profile |
+| **Nordic** | `NP` | `NP` | Nordic-specific extensions and conventions |
+
+Examples are named by profile: `Example_<Object>_MIN.xml`, `Example_<Object>_NP.xml`, etc.
+
+### Codespace conventions
+
+XML identifiers follow the pattern `<Codespace>:<ObjectType>:<Identifier>`:
 
 ```
-PublicationDelivery → dataObjects → CompositeFrame → frames → …
+ERP:DayType:WKD           ← European profile example
+NP:ServiceJourney:15044   ← Nordic profile example
+NSR:StopPlace:59977       ← Norwegian StopPlace Registry (stop infrastructure)
 ```
 
-### 2. **Human‑oriented documentation**
-For every frame or object, you will find:
-- A description file explaining purpose, usage, and relationships
-- A structured table outlining elements, cardinality, and type information
-- One or more XML examples showing how to model the entity
+> `NSR` is reserved for stop infrastructure data (StopPlace, Quay, TopographicPlace) in Nordic Profile examples.
 
-### 3. **A centralized navigation index**
-Located at:
-```
-LLM/TableOfExamples.md
-```
-This file provides an alphabetically ordered list of all examples, together with links to documentation and tables.
+The `ParticipantRef` in all examples uses `EuPro` to identify this as European Profile documentation.
 
 ---
 
@@ -45,113 +98,79 @@ This file provides an alphabetically ordered list of all examples, together with
 
 ```
 Root
+├── Guides/                         → Conceptual guides (one folder per guide)
+│     └── <GuideName>/
+│          ├── <GuideName>.md
+│          └── (optional supporting files)
 │
-├── Guides/                 → Introductory material and conceptual explanations
-├── Frames/                 → Documentation and examples grouped by Frame
+├── Frames/                         → Frame-level documentation and examples
 │     └── <FrameName>/
-│          ├── Description_*.md
-│          ├── Table_*.md
-│          └── Example_*.xml
+│          ├── Description_<FrameName>.md
+│          ├── Table_<FrameName>.md
+│          └── Example_<FrameName>.xml
 │
-├── Objects/                → Documentation and examples for individual NeTEx objects
+├── Objects/                        → Object-level documentation and examples
 │     └── <ObjectName>/
-│          ├── Description_*.md
-│          ├── Table_*.md
-│          └── Example_*.xml
+│          ├── Description_<ObjectName>.md
+│          ├── Table_<ObjectName>.md
+│          └── Example_<ObjectName>_<Profile>.xml
 │
-├── LLM/
-│     ├── README.md
-│     └── TableOfExamples.md → Central index of all examples
+├── LLM/                            → Documentation conventions and indexes
+│     ├── README.md                 → Rules and templates for documentation
+│     ├── Tables/                   → Table of Contents + Table of Examples
+│     ├── Templates/                → Templates for creating new documentation
+│     └── AgentGuides/              → Operational guides for AI-assisted workflows
+│
+├── scripts/                        → Local validation tools
+│     └── validate-xml.sh
+│
+└── .github/workflows/              → CI validation (PR + push)
 ```
 
 ---
 
 ## 🧱 Conventions
 
-### **File naming**
-| Type | Naming | 
-|------|--------|
-| XML examples | `Example_*.xml` |
-| Descriptions | `Description_*.md` |
-| Tables | `Table_*.md` |
+### File naming
 
-### **Codespace**
-All XML identifiers use the `ERP` codespace:
-```
-ERP:<ObjectType>:<Identifier>
-```
-Example:
-```
-ERP:DayType:WKD
-```
+| Type | Pattern | Example |
+|------|---------|---------|
+| XML examples | `Example_<Name>_<Profile>.xml` | `Example_Line_MIN.xml` |
+| Descriptions | `Description_<Name>.md` | `Description_Line.md` |
+| Tables | `Table_<Name>.md` | `Table_Line.md` |
 
-### **XML structure principles**
-- Consistent element naming (`lowerCamelCase` for collections)
-- `*Ref` elements used for relationships
-- Minimal but valid examples
-- Time values use timezone-aware `xs:dateTime`
-  → `2026-02-25T14:22:00Z`
+### XML structure principles
+
+- Collections use `lowerCamelCase` (`dataObjects`, `vehicleJourneys`, `pointsInSequence`)
+- Type elements use `UpperCamelCase` (`ServiceJourney`, `StopPlace`)
+- `*Ref` elements express relationships between objects
+- Element order must match the NeTEx XSD sequence (inherited elements first)
+- Time values use timezone-aware `xs:dateTime` → `2026-02-25T14:22:00Z`
+- All examples are validated against `XSD 2.0/xsd/NeTEx_publication.xsd`
 
 ---
 
-## 🔄 How to Add or Update an Example
+## ✅ Validation
 
-### 1. Add three files in the correct directory
-- `Example_<Name>.xml`
-- `Description_<Name>.md`
-- `Table_<Name>.md`
+All XML examples in this repository are validated against the official NeTEx XSD schema, both locally and in CI.
 
-Use the master templates found in the Guides/ folder whenever applicable.
+| Method | How |
+|--------|-----|
+| **Local (bash)** | `./scripts/validate-xml.sh` |
+| **Local (changed only)** | `./scripts/validate-xml.sh --changed` |
+| **CI (pull request)** | Automatic via `PR_Validator.yml` |
+| **CI (push)** | Automatic via `Commit_Validator.yml` on `EnStandardBranch` |
 
-### 2. Update the navigation index
-In:
-```
-LLM/TableOfExamples.md
-```
-Add a new row with:
-- Relative path to the XML example
-- Links to description and table
-- Alphabetical ordering
-- Verified working links
-
-### 3. Verify links in the target branch
-All links must resolve correctly before opening a pull request.
+See the [Validation guide](Guides/Validation/) for detailed instructions.
 
 ---
 
-## 🧩 Template Structures
+## ✨ About This Project
 
-### **Description_*.md**
-Should include:
-- Purpose
-- Typical elements
-- Key relationships
-- Notes related to examples
-
-### **Table_*.md**
-Standard columns:
-| Element | Type | Cardinality | Notes |
-
-### **Example_*.xml**
-A minimal but correct XML example, using ERP codespace and consistent structure.
-
----
-
-## 📚 How to Use This Repository for Learning
-1. Begin in `Guides/` to understand the overall context
-2. Explore `Frames/` for structural patterns
-3. Dive into `Objects/` for detailed reference material
-4. Use the index in `LLM/TableOfExamples.md` for quick lookup
-5. Compare XML examples with table documentation
-6. Read description files to understand modeling intent
-
----
-
-## ✨ Goal of This Repository
 This project exists to make NeTEx easier to understand and apply by providing:
-- Clear documentation
-- Consistent modeling patterns
-- A rich library of examples
-- A unified reference structure
+- Clear, structured documentation for every object and frame
+- A rich library of validated examples across multiple profiles
+- Conceptual guides for newcomers and practitioners alike
+- Consistent conventions that make the standard predictable and navigable
 
-It is designed to help both newcomers and experienced practitioners work with NeTEx in a predictable, well-documented, and transparent way.
+Whether you're encountering NeTEx for the first time or looking up a specific element's cardinality, this repository is designed to get you to the answer quickly.


### PR DESCRIPTION
Rewrite for readers/learners rather than contributors:
- Add Profiles section (MIN/ERP/NP) with codespace conventions
- Add Validation section with local + CI methods
- Add Guides table listing all 7 guides
- Update repository structure tree to match reality
- Fix all stale references (LLM/TableOfExamples.md -> LLM/Tables/)
- Replace contributor workflow sections with navigation-first layout
- Add quick lookup links to TableOfContent and TableOfExamples