### PR TITLE
docs: Add CompositeFrame documentation, harmonize ParticipantRef to E…

### DIFF
--- a/Frames/CompositeFrame/Description_CompositeFrame.md
+++ b/Frames/CompositeFrame/Description_CompositeFrame.md
@@ -1,0 +1,52 @@
+# CompositeFrame
+
+## 1. Purpose
+
+A **CompositeFrame** groups multiple frames into a single, coherent delivery unit within a `PublicationDelivery`. It acts as a top-level container that holds any combination of ResourceFrame, ServiceFrame, TimetableFrame, and other frame types, enabling cross-frame reference resolution within the same file.
+
+## 2. Structure Overview
+
+```text
+📄 @id (1..1)
+📄 @version (1..1)
+📁 codespaces (0..1)
+   └── 📄 Codespace (1..n)
+📄 FrameDefaults (0..1)
+   └── 🔗 DefaultCodespaceRef (0..1)
+📁 frames (0..1)
+   ├── 📄 ResourceFrame (0..n)
+   ├── 📄 SiteFrame (0..n)
+   ├── 📄 ServiceCalendarFrame (0..n)
+   ├── 📄 ServiceFrame (0..n)
+   ├── 📄 TimetableFrame (0..n)
+   ├── 📄 VehicleScheduleFrame (0..n)
+   ├── 📄 FareFrame (0..n)
+   └── 📄 SalesTransactionFrame (0..n)
+```
+
+## 3. Contained Elements
+
+- **codespaces** – Collection of [Codespace](../../Objects/Codespace/Table_Codespace.md) definitions declaring XML namespace prefixes shared across all contained frames
+- **FrameDefaults** – Default settings applied to all contained frames, including `DefaultCodespaceRef`
+- **frames** – Collection of child frames, accepting any combination of:
+  - [ResourceFrame](../ResourceFrame/Table_ResourceFrame.md) – Organizations, operators, and shared resources
+  - [SiteFrame](../SiteFrame/Table_SiteFrame.md) – Stop places and physical infrastructure
+  - [ServiceCalendarFrame](../ServiceCalendarFrame/Table_ServiceCalendarFrame.md) – Day types, operating periods, and calendars
+  - [ServiceFrame](../ServiceFrame/Table_ServiceFrame.md) – Lines, routes, journey patterns, and stop assignments
+  - [TimetableFrame](../TimetableFrame/Table_TimetableFrame.md) – Service journeys and interchanges
+  - [VehicleScheduleFrame](../VehicleScheduleFrame/Table_VehicleScheduleFrame.md) – Vehicle scheduling and block assignments
+  - [FareFrame](../FareFrame/Table_FareFrame.md) – Fares, tariffs, and fare products
+  - [SalesTransactionFrame](../SalesTransactionFrame/Table_SalesTransactionFrame.md) – Sales transactions and fare contracts
+
+## 4. Frame Relationships
+
+CompositeFrame sits directly inside `PublicationDelivery/dataObjects` as the top-level grouping container. All other frame types are placed inside the CompositeFrame's `frames` collection. By grouping frames together, CompositeFrame enables versioned `*Ref` elements to resolve across frame boundaries within the same file — for example, a `ServiceJourney` in a TimetableFrame can reference a `DayType` in a ServiceCalendarFrame without triggering keyref validation errors.
+
+For the full structural specification, see [Table — CompositeFrame](Table_CompositeFrame.md).
+Example XML: [Example_CompositeFrame.xml](Example_CompositeFrame.xml)
+
+## 5. Usage Notes
+
+- **Frame ordering convention**: ResourceFrame → SiteFrame → ServiceCalendarFrame → ServiceFrame → TimetableFrame → VehicleScheduleFrame → FareFrame → SalesTransactionFrame. This convention places foundational data (organizations, stops) before dependent data (journeys, fares).
+- **Codespace placement**: Codespaces can be declared either on the CompositeFrame itself (shared by all contained frames) or on individual ResourceFrames within the `frames` collection. Declaring on CompositeFrame is preferred when multiple frames share the same codespace.
+- **FrameDefaults**: When `DefaultCodespaceRef` is set, all contained frames inherit it, avoiding the need to repeat codespace references in each child frame.

--- a/Frames/CompositeFrame/Example_CompositeFrame.xml
+++ b/Frames/CompositeFrame/Example_CompositeFrame.xml
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<PublicationDelivery xmlns="http://www.netex.org.uk/netex" version="2.0">
+  <PublicationTimestamp>2026-03-18T00:00:00Z</PublicationTimestamp>
+  <ParticipantRef>EuPro</ParticipantRef>
+  <dataObjects>
+    <CompositeFrame id="ERP:CompositeFrame:1" version="1">
+      <codespaces>
+        <Codespace id="erp">
+          <Xmlns>ERP</Xmlns>
+          <XmlnsUrl>http://www.europeanprofile.eu/ERP</XmlnsUrl>
+        </Codespace>
+      </codespaces>
+      <FrameDefaults>
+        <DefaultCodespaceRef ref="erp"/>
+      </FrameDefaults>
+      <frames>
+        <ResourceFrame id="ERP:ResourceFrame:1" version="1">
+          <organisations>
+            <Authority id="ERP:Authority:AUT_001" version="1">
+              <Name>Example Authority</Name>
+            </Authority>
+            <Operator id="ERP:Operator:OP_001" version="1">
+              <Name>Example Operator</Name>
+            </Operator>
+          </organisations>
+        </ResourceFrame>
+        <ServiceCalendarFrame id="ERP:ServiceCalendarFrame:1" version="1">
+          <dayTypes>
+            <DayType id="ERP:DayType:WKD" version="1">
+              <Name>Weekdays</Name>
+              <properties>
+                <PropertyOfDay>
+                  <DaysOfWeek>Monday Tuesday Wednesday Thursday Friday</DaysOfWeek>
+                </PropertyOfDay>
+              </properties>
+            </DayType>
+          </dayTypes>
+        </ServiceCalendarFrame>
+        <ServiceFrame id="ERP:ServiceFrame:1" version="1">
+          <lines>
+            <Line id="ERP:Line:L1" version="1">
+              <Name>Line 1</Name>
+              <PublicCode>1</PublicCode>
+              <OperatorRef ref="ERP:Operator:OP_001"/>
+            </Line>
+          </lines>
+        </ServiceFrame>
+        <TimetableFrame id="ERP:TimetableFrame:1" version="1">
+          <vehicleJourneys>
+            <ServiceJourney id="ERP:ServiceJourney:SJ_001" version="1">
+              <Name>Morning departure</Name>
+              <dayTypes>
+                <DayTypeRef ref="ERP:DayType:WKD"/>
+              </dayTypes>
+              <LineRef ref="ERP:Line:L1"/>
+            </ServiceJourney>
+          </vehicleJourneys>
+        </TimetableFrame>
+      </frames>
+    </CompositeFrame>
+  </dataObjects>
+</PublicationDelivery>

--- a/Frames/CompositeFrame/Table_CompositeFrame.md
+++ b/Frames/CompositeFrame/Table_CompositeFrame.md
@@ -1,0 +1,42 @@
+# CompositeFrame
+
+## Structure Overview
+
+```text
+CompositeFrame
+ ├─ @id (1..1)
+ ├─ @version (1..1)
+ ├─ codespaces (0..1)
+ │   └─ Codespace (1..n)
+ ├─ FrameDefaults (0..1)
+ │   └─ DefaultCodespaceRef (0..1)
+ └─ frames (0..1)
+     ├─ ResourceFrame (0..n)
+     ├─ SiteFrame (0..n)
+     ├─ ServiceCalendarFrame (0..n)
+     ├─ ServiceFrame (0..n)
+     ├─ TimetableFrame (0..n)
+     ├─ VehicleScheduleFrame (0..n)
+     ├─ FareFrame (0..n)
+     └─ SalesTransactionFrame (0..n)
+```
+
+## Table
+
+| Element | Type | Description | Path |
+|---------|------|-------------|------|
+| @id | ID | Unique identifier for the CompositeFrame | CompositeFrame/@id |
+| @version | String | Version number for change tracking | CompositeFrame/@version |
+| codespaces | Container | Collection of Codespace declarations shared by all contained frames | CompositeFrame/codespaces |
+| [Codespace](../../Objects/Codespace/Table_Codespace.md) | Element | XML namespace prefix definition with Xmlns and XmlnsUrl | CompositeFrame/codespaces/Codespace |
+| FrameDefaults | Container | Default settings inherited by all contained frames | CompositeFrame/FrameDefaults |
+| DefaultCodespaceRef | Reference | Reference to the default Codespace for contained frames | CompositeFrame/FrameDefaults/DefaultCodespaceRef |
+| frames | Container | Collection of child frames making up the delivery | CompositeFrame/frames |
+| [ResourceFrame](../ResourceFrame/Table_ResourceFrame.md) | Element | Organizations, operators, and shared resources | CompositeFrame/frames/ResourceFrame |
+| [SiteFrame](../SiteFrame/Table_SiteFrame.md) | Element | Stop places and physical infrastructure | CompositeFrame/frames/SiteFrame |
+| [ServiceCalendarFrame](../ServiceCalendarFrame/Table_ServiceCalendarFrame.md) | Element | Day types, operating periods, and calendars | CompositeFrame/frames/ServiceCalendarFrame |
+| [ServiceFrame](../ServiceFrame/Table_ServiceFrame.md) | Element | Lines, routes, journey patterns, and stop assignments | CompositeFrame/frames/ServiceFrame |
+| [TimetableFrame](../TimetableFrame/Table_TimetableFrame.md) | Element | Service journeys and interchanges | CompositeFrame/frames/TimetableFrame |
+| [VehicleScheduleFrame](../VehicleScheduleFrame/Table_VehicleScheduleFrame.md) | Element | Vehicle scheduling and block assignments | CompositeFrame/frames/VehicleScheduleFrame |
+| [FareFrame](../FareFrame/Table_FareFrame.md) | Element | Fares, tariffs, and fare products | CompositeFrame/frames/FareFrame |
+| [SalesTransactionFrame](../SalesTransactionFrame/Table_SalesTransactionFrame.md) | Element | Sales transactions and fare contracts | CompositeFrame/frames/SalesTransactionFrame |

--- a/Frames/FareFrame/Example_FareFrame.xml
+++ b/Frames/FareFrame/Example_FareFrame.xml
@@ -1,6 +1,6 @@
 <PublicationDelivery version="2.0" xmlns="http://www.netex.org.uk/netex" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <PublicationTimestamp>2026-02-27T23:15:00Z</PublicationTimestamp>
-  <ParticipantRef>ERP</ParticipantRef>
+  <ParticipantRef>EuPro</ParticipantRef>
   <dataObjects>
     <CompositeFrame id="ERP:CompositeFrame:CF_1" version="1">
       <frames>

--- a/LLM/Tables/TableOfContent.md
+++ b/LLM/Tables/TableOfContent.md
@@ -16,6 +16,7 @@ How-to guides, conceptual overviews, and reference material:
 
 Documentation for NeTEx frames (containers):
 
+- [CompositeFrame](../../Frames/CompositeFrame/) – Container frame grouping multiple frames into a single delivery
 - [FareFrame](../../Frames/FareFrame/) – Fares, tariffs and fare products
 - [ResourceFrame](../../Frames/ResourceFrame/) – Organizations and resources
 - [SalesTransactionFrame](../../Frames/SalesTransactionFrame/) – Sales transaction data

--- a/LLM/Tables/TableOfExamples.md
+++ b/LLM/Tables/TableOfExamples.md
@@ -5,6 +5,7 @@ Complete index of all XML examples in the repository.
 ## Frames
 
 - [Example_PublicationDelivery.xml](../../Frames/Example_PublicationDelivery.xml) – Root container with composite frame structure
+- [Example_CompositeFrame.xml](../../Frames/CompositeFrame/Example_CompositeFrame.xml) – Composite frame grouping multiple frames
 - [Example_FareFrame.xml](../../Frames/FareFrame/Example_FareFrame.xml) – Fares and tariffs structure with products and validations
 - [Example_ResourceFrame.xml](../../Frames/ResourceFrame/Example_ResourceFrame.xml) – Organizations, operators, and resources
 - [Example_ServiceCalendarFrame.xml](../../Frames/ServiceCalendarFrame/Example_ServiceCalendarFrame.xml) – Service calendars and day types

--- a/Objects/Codespace/Example_Codespace.xml
+++ b/Objects/Codespace/Example_Codespace.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <PublicationDelivery xmlns="http://www.netex.org.uk/netex" xmlns:gml="http://www.opengis.net/gml/3.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:siri="http://www.siri.org.uk/siri" version="2.0">
   <PublicationTimestamp>2026-02-28T13:37:46.0Z</PublicationTimestamp>
-  <ParticipantRef>ERP</ParticipantRef>
+  <ParticipantRef>EuPro</ParticipantRef>
   <Description>Minimal example using ERP as the codespace</Description>
   <dataObjects>
     <CompositeFrame id="ERP:CompositeFrame:CF_1" version="1">

--- a/Objects/DatedServiceJourney/Example_DatedServiceJourney_ERP.xml
+++ b/Objects/DatedServiceJourney/Example_DatedServiceJourney_ERP.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <PublicationDelivery xmlns="http://www.netex.org.uk/netex" xmlns:gml="http://www.opengis.net/gml/3.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:siri="http://www.siri.org.uk/siri" version="1.0">
     <PublicationTimestamp>2022-02-15T09:30:46.0Z</PublicationTimestamp>
-    <ParticipantRef>ERP</ParticipantRef>
+    <ParticipantRef>EuPro</ParticipantRef>
     <dataObjects>
         <TimetableFrame version="1" id="ERP:TimetableFrame:1">
             <vehicleJourneys>

--- a/Objects/DatedServiceJourney/Example_DatedServiceJourney_Extended_02_Replacement.xml
+++ b/Objects/DatedServiceJourney/Example_DatedServiceJourney_Extended_02_Replacement.xml
@@ -12,7 +12,7 @@
 -->
 <PublicationDelivery xmlns="http://www.netex.org.uk/netex" xmlns:gml="http://www.opengis.net/gml/3.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:siri="http://www.siri.org.uk/siri" version="1.0">
     <PublicationTimestamp>2026-03-01T10:00:00Z</PublicationTimestamp>
-    <ParticipantRef>ERP</ParticipantRef>  
+    <ParticipantRef>EuPro</ParticipantRef>  
     <dataObjects>
             <TimetableFrame version="1" id="ERP:TimetableFrame:1">
                 <vehicleJourneys>

--- a/Objects/DatedServiceJourney/Example_DatedServiceJourney_Extended_03_BlockLinked.xml
+++ b/Objects/DatedServiceJourney/Example_DatedServiceJourney_Extended_03_BlockLinked.xml
@@ -10,7 +10,7 @@
 -->
 <PublicationDelivery xmlns="http://www.netex.org.uk/netex" xmlns:gml="http://www.opengis.net/gml/3.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:siri="http://www.siri.org.uk/siri" version="1.0">
     <PublicationTimestamp>2026-03-01T10:00:00Z</PublicationTimestamp>
-    <ParticipantRef>ERP</ParticipantRef>    
+    <ParticipantRef>EuPro</ParticipantRef>    
     <dataObjects>
         <TimetableFrame version="1" id="ERP:TimetableFrame:1">
             <vehicleJourneys>

--- a/Objects/DatedServiceJourney/Example_DatedServiceJourney_Extended_04_MultiRef.xml
+++ b/Objects/DatedServiceJourney/Example_DatedServiceJourney_Extended_04_MultiRef.xml
@@ -13,7 +13,7 @@
 -->
 <PublicationDelivery xmlns="http://www.netex.org.uk/netex" xmlns:gml="http://www.opengis.net/gml/3.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:siri="http://www.siri.org.uk/siri" version="1.0">
     <PublicationTimestamp>2026-03-01T10:00:00Z</PublicationTimestamp>
-    <ParticipantRef>ERP</ParticipantRef>   
+    <ParticipantRef>EuPro</ParticipantRef>   
     <dataObjects>
         <TimetableFrame version="1" id="ERP:TimetableFrame:1">
             <vehicleJourneys>

--- a/Objects/DatedServiceJourney/Example_DatedServiceJourney_MIN.xml
+++ b/Objects/DatedServiceJourney/Example_DatedServiceJourney_MIN.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <PublicationDelivery xmlns="http://www.netex.org.uk/netex" xmlns:gml="http://www.opengis.net/gml/3.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:siri="http://www.siri.org.uk/siri" version="1.0">
     <PublicationTimestamp>2022-02-15T09:30:46.0Z</PublicationTimestamp>
-    <ParticipantRef>ERP</ParticipantRef>
+    <ParticipantRef>EuPro</ParticipantRef>
     <dataObjects>
         <TimetableFrame version="1" id="ERP:TimetableFrame:1">
             <vehicleJourneys>

--- a/Objects/GroupOfLines/Example_GroupOfLines.xml
+++ b/Objects/GroupOfLines/Example_GroupOfLines.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <PublicationDelivery xmlns="http://www.netex.org.uk/netex" version="2.0">
     <PublicationTimestamp>2026-03-04T00:00:00Z</PublicationTimestamp>
-    <ParticipantRef>ERP</ParticipantRef>
+    <ParticipantRef>EuPro</ParticipantRef>
     <dataObjects>
         <CompositeFrame id="ERP:CompositeFrame:1" version="1">
             <frames>

--- a/Objects/Line/Example_Line_MIN.xml
+++ b/Objects/Line/Example_Line_MIN.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <PublicationDelivery xmlns="http://www.netex.org.uk/netex" version="2.0">
   <PublicationTimestamp>2026-03-04T00:00:00Z</PublicationTimestamp>
-  <ParticipantRef>ERP</ParticipantRef>
+  <ParticipantRef>EuPro</ParticipantRef>
   <dataObjects>
     <CompositeFrame id="ERP:CompositeFrame:1" version="1">
       <frames>

--- a/Objects/ResponsibilitySet/Example_ResponsibilitySet_Contract.xml
+++ b/Objects/ResponsibilitySet/Example_ResponsibilitySet_Contract.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <PublicationDelivery xmlns="http://www.netex.org.uk/netex" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="2.0">
     <PublicationTimestamp>2026-03-04T10:00:00+01:00</PublicationTimestamp>
-    <ParticipantRef>ERP</ParticipantRef>
+    <ParticipantRef>EuPro</ParticipantRef>
     <dataObjects>
         <CompositeFrame id="ERP:CompositeFrame:EXAMPLE_1" version="1">
             <codespaces>

--- a/Objects/StopPlace/Example_StopPlace_MIN.xml
+++ b/Objects/StopPlace/Example_StopPlace_MIN.xml
@@ -3,7 +3,7 @@
                      xmlns:gml="http://www.opengis.net/gml/3.2"
                      version="1.0">
   <PublicationTimestamp>2026-02-15T11:00:00Z</PublicationTimestamp>
-  <ParticipantRef>ERP</ParticipantRef>
+  <ParticipantRef>EuPro</ParticipantRef>
   <dataObjects>
     <SiteFrame id="ERP:SiteFrame:StopPlaceExample" version="1">
       <stopPlaces>

--- a/Objects/TrainBlock/Example_TrainBlock.xml
+++ b/Objects/TrainBlock/Example_TrainBlock.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <PublicationDelivery xmlns="http://www.netex.org.uk/netex" version="2.0">
   <PublicationTimestamp>2026-02-23T13:45:00Z</PublicationTimestamp>
-  <ParticipantRef>ERP</ParticipantRef>
+  <ParticipantRef>EuPro</ParticipantRef>
   <dataObjects>
     <CompositeFrame id="ERP:CompositeFrame:CF:1" version="1">
       <frames>


### PR DESCRIPTION
…uPro

Add full documentation package for CompositeFrame (Description, Table, validated XML example) under Frames/CompositeFrame/. Update TableOfContent and TableOfExamples indexes. Fix remaining 12 XML files that still had ParticipantRef set to ERP instead of EuPro.