### PR TITLE
Sync tables with new guides

### DIFF
--- a/LLM/Tables/TableOfContent.md
+++ b/LLM/Tables/TableOfContent.md
@@ -15,6 +15,9 @@ How-to guides, conceptual overviews, and reference material:
 - [JourneyLifecycle](../../Guides/JourneyLifecycle/JourneyLifecycle_Guide.md) – Line → Route → JourneyPattern → ServiceJourney → DatedServiceJourney
 - [VehicleScheduling](../../Guides/VehicleScheduling/VehicleScheduling_Guide.md) – Blocks, VehicleType, Vehicle, and fleet assignment
 - [PassengerInformation](../../Guides/PassengerInformation/PassengerInformation_Guide.md) – DestinationDisplay, Notice, and FlexibleServiceProperties
+- [Accessibility](../../Guides/Accessibility/Accessibility_Guide.md) – AccessibilityAssessment, equipment, and indoor navigation paths
+- [FareModelling](../../Guides/FareModelling/FareModelling_Guide.md) – Products, zones, tariffs, and sales offer packages
+- [DecisionMakers](../../Guides/DecisionMakers/DecisionMakers_Guide.md) – NeTEx overview for decision makers and stakeholders
 - [Glossary](../../Guides/Glossary/) – Terminology and definitions
 
 ## Frames

--- a/LLM/Tables/TableOfExamples.md
+++ b/LLM/Tables/TableOfExamples.md
@@ -2,6 +2,17 @@
 
 Complete index of all XML examples in the repository.
 
+## Guides
+
+- [Example_SeparationOfConcerns.xml](../../Guides/SeparationOfConcerns/Example_SeparationOfConcerns.xml) – Multi-frame delivery demonstrating domain separation
+- [Example_Interchange.xml](../../Guides/InterchangeOnly/Example_Interchange.xml) – Planned transfers and guaranteed connections
+- [Example_OrganisationalGovernance.xml](../../Guides/OrganisationalGovernance/Example_OrganisationalGovernance.xml) – Authority, Operator, Contract, and ResponsibilitySet
+- [Example_StopInfrastructure.xml](../../Guides/StopInfrastructure/Example_StopInfrastructure.xml) – Logical stops, physical platforms, and stop assignments
+- [Example_JourneyLifecycle.xml](../../Guides/JourneyLifecycle/Example_JourneyLifecycle.xml) – Line through Route, JourneyPattern, and ServiceJourney
+- [Example_VehicleScheduling.xml](../../Guides/VehicleScheduling/Example_VehicleScheduling.xml) – Blocks, VehicleType, Vehicle, and fleet assignment
+- [Example_Accessibility.xml](../../Guides/Accessibility/Example_Accessibility.xml) – AccessibilityAssessment, equipment, and indoor navigation
+- [Example_FareModelling.xml](../../Guides/FareModelling/Example_FareModelling.xml) – Products, zones, tariffs, and sales offer packages
+
 ## Frames
 
 - [Example_PublicationDelivery.xml](../../Frames/Example_PublicationDelivery.xml) – Root container with composite frame structure

--- a/README.md
+++ b/README.md
@@ -67,6 +67,9 @@ Each guide lives in its own folder under [`Guides/`](Guides/) and can include su
 | [JourneyLifecycle](Guides/JourneyLifecycle/JourneyLifecycle_Guide.md) | Line → Route → JourneyPattern → ServiceJourney → DatedServiceJourney |
 | [VehicleScheduling](Guides/VehicleScheduling/VehicleScheduling_Guide.md) | Blocks, VehicleType, Vehicle, and fleet assignment |
 | [PassengerInformation](Guides/PassengerInformation/PassengerInformation_Guide.md) | DestinationDisplay, Notice, and FlexibleServiceProperties |
+| [Accessibility](Guides/Accessibility/Accessibility_Guide.md) | AccessibilityAssessment, equipment, and indoor navigation paths |
+| [FareModelling](Guides/FareModelling/FareModelling_Guide.md) | Products, zones, tariffs, and sales offer packages |
+| [DecisionMakers](Guides/DecisionMakers/DecisionMakers_Guide.md) | NeTEx overview for decision makers and stakeholders |
 | [Glossary](Guides/Glossary/) | Terminology and definitions |
 
 ---


### PR DESCRIPTION
## Summary
- Add 3 missing guides (Accessibility, FareModelling, DecisionMakers) to **TableOfContent.md** and **README.md**
- Add new **Guides** section to **TableOfExamples.md** listing all 8 guide XML examples

## Test plan
- [ ] Verify all links in TableOfContent.md, TableOfExamples.md, and README.md resolve correctly
- [ ] Confirm no guides or guide examples are missing from the index tables

?? Generated with [Claude Code](https://claude.com/claude-code)