### PR TITLE
Add RegulatoryCompliance and MaaSConsumers guides

### DIFF
--- a/Guides/MaaSConsumers/MaaSConsumers_Guide.md
+++ b/Guides/MaaSConsumers/MaaSConsumers_Guide.md
@@ -1,0 +1,209 @@
+# 🔄 NeTEx for MaaS Providers — Consuming NeTEx Datasets
+
+## 1. 🎯 Introduction
+
+Most NeTEx documentation assumes you are producing data. But if you are building a MaaS platform, journey planner, or integration layer, you are a **consumer** — you receive NeTEx deliveries and need to extract, parse, and map them to your internal models. The challenges are different: instead of asking "am I compliant?", you are asking "can I use this data?".
+
+In this guide you will learn:
+- 🔄 How the consumer perspective differs from the producer perspective
+- 📄 What to expect inside a NeTEx PublicationDelivery
+- 🔍 Two parsing strategies and when to use each
+- 🧩 Which NeTEx objects a MaaS platform typically needs
+- ⚙️ How to handle profiles and missing data gracefully
+- 🗺️ Principles for mapping NeTEx to your internal domain model
+- 📡 How NeTEx relates to SIRI for real-time data
+
+---
+
+## 2. 🔄 Consumer vs Producer
+
+Producers (operators, authorities) create NeTEx data following profile rules. Consumers (MaaS apps, journey planners, aggregators) receive and interpret that data. The concerns are fundamentally different:
+
+| Concern | Producer | Consumer |
+|---------|----------|----------|
+| Primary question | "Am I compliant?" | "Can I use this data?" |
+| Data quality | Ensuring completeness and validity | Handling incompleteness gracefully |
+| Profile rules | Must follow mandatory elements | Must tolerate optional elements being absent |
+| Versioning | Publishes new versions | Detects and processes changes |
+| Tooling | XML editors, validators | Parsers, mappers, data pipelines |
+
+> 💡 **Tip:** Even as a consumer, understanding the producer's constraints helps you anticipate data quality. Read the [Get Started](../GetStarted/GetStarted_Guide.md) guide to understand the structural rules producers follow.
+
+---
+
+## 3. 📄 What to Expect in a NeTEx Delivery
+
+Every NeTEx delivery is a `PublicationDelivery` XML document. The data lives inside `dataObjects`, typically wrapped in a `CompositeFrame`:
+
+```text
+PublicationDelivery
+ ├── PublicationTimestamp       "When was this published?"
+ ├── ParticipantRef             "Who published it?"
+ └── dataObjects
+      └── CompositeFrame
+           ├── ResourceFrame          Authorities, Operators
+           ├── SiteFrame              Stops, Quays, Accessibility
+           ├── ServiceCalendarFrame   When services run
+           ├── ServiceFrame           Lines, Routes, JourneyPatterns
+           ├── TimetableFrame         Journeys, passing times
+           ├── VehicleScheduleFrame   Vehicle assignments (may be absent)
+           └── FareFrame              Fare products (may be absent)
+```
+
+Not every delivery contains all frames. A stop-only delivery may contain just SiteFrame. A timetable update may skip SiteFrame entirely.
+
+> ⚠️ **Note:** Never assume a frame is present. Your parser should handle deliveries with any subset of frames.
+
+See the [Get Started](../GetStarted/GetStarted_Guide.md) guide for a full explanation of the document anatomy.
+
+---
+
+## 4. 🔍 Parsing Strategies
+
+There are two main approaches to extracting data from a NeTEx delivery:
+
+### Frame-first (recommended)
+
+Walk the CompositeFrame and process each frame by type:
+
+```text
+CompositeFrame
+ ├── iterate each frame by type
+ │    ├── ResourceFrame  → extract Operators, Authorities
+ │    ├── SiteFrame      → extract StopPlaces, Quays
+ │    ├── ServiceFrame   → extract Lines, Routes, JourneyPatterns
+ │    └── TimetableFrame → extract ServiceJourneys
+ └── resolve cross-frame references afterward
+```
+
+### Object-first
+
+Search for specific elements regardless of frame structure:
+
+```text
+XML document
+ └── find elements by name across the entire tree:
+      ├── all <ServiceJourney> elements
+      ├── all <StopPlace> elements
+      └── resolve references as encountered
+```
+
+### Comparison
+
+| Aspect | Frame-first | Object-first |
+|--------|-------------|--------------|
+| Structure awareness | High — respects domain boundaries | Low — flattens frame structure |
+| Implementation | Walk the XML tree top-down | XPath / element search |
+| Best for | Full dataset imports | Targeted extraction (e.g. only stops) |
+| Risk | Misses objects in unexpected frames | May find duplicate objects across frames |
+
+> 💡 **Tip:** Frame-first is the recommended approach for full dataset consumption. It respects NeTEx's domain architecture and makes reference resolution predictable. See [Separation of Concerns](../SeparationOfConcerns/SeparationOfConcerns.md) for why frames are organized this way.
+
+---
+
+## 5. 🧩 Key Objects for MaaS Platforms
+
+The table below maps common MaaS use cases to the NeTEx objects you need, and which frame they live in:
+
+| MaaS Use Case | NeTEx Objects | Found In | Guide |
+|---------------|---------------|----------|-------|
+| Show nearby stops | StopPlace, Quay, Location | SiteFrame | [StopInfrastructure](../StopInfrastructure/StopInfrastructure_Guide.md) |
+| Display routes | Line, Route | ServiceFrame | [JourneyLifecycle](../JourneyLifecycle/JourneyLifecycle_Guide.md) |
+| Show departures | ServiceJourney, TimetabledPassingTime | TimetableFrame | [JourneyLifecycle](../JourneyLifecycle/JourneyLifecycle_Guide.md) |
+| Journey planning | JourneyPattern, ScheduledStopPoint | ServiceFrame | [JourneyLifecycle](../JourneyLifecycle/JourneyLifecycle_Guide.md) |
+| Ticket purchase | PreassignedFareProduct, SalesOfferPackage | FareFrame | [FareModelling](../FareModelling/FareModelling_Guide.md) |
+| Accessibility filter | AccessibilityAssessment | SiteFrame | [Accessibility](../Accessibility/Accessibility_Guide.md) |
+| Operator info | Operator, Authority | ResourceFrame | [OrganisationalGovernance](../OrganisationalGovernance/OrganisationalGovernance_Guide.md) |
+| Transfers | ServiceJourneyInterchange | TimetableFrame | [Interchange](../InterchangeOnly/Interchange_Guide.md) |
+
+Objects reference each other by `id` and `ref` across frames. Your parser must build an ID-to-object map to resolve `*Ref` elements (e.g. a ServiceJourney's `JourneyPatternRef` points to a JourneyPattern in ServiceFrame).
+
+---
+
+## 6. ⚙️ Handling Profiles and Missing Data
+
+NeTEx profiles define cardinality for each element: mandatory, optional, or not used. Different producers may use different profiles (MIN, ERP, Nordic Profile), which means the same element can be mandatory in one delivery and absent in another.
+
+| Element | MIN profile | ERP profile | Nordic Profile |
+|---------|-------------|-------------|----------------|
+| StopPlace.Name | Mandatory | Mandatory | Mandatory |
+| Quay.PublicCode | Optional | Recommended | Mandatory |
+| AccessibilityAssessment | Not used | Recommended | Mandatory |
+
+What this means for consumers:
+- Your parser should **never crash on a missing optional element**
+- Design your data model with nullable fields for anything not universally mandatory
+- If you ingest from multiple sources, expect different levels of completeness
+
+> 💡 **Tip:** Check which profile a delivery was produced under. The `ParticipantRef` and codespace conventions can give you hints. See [Decision Makers](../DecisionMakers/DecisionMakers_Guide.md) for a profile overview.
+
+---
+
+## 7. 🗺️ Mapping NeTEx to Internal Models
+
+When importing NeTEx into your system, you will need to map its object model to your internal domain. Here is a typical conceptual mapping:
+
+```text
+NeTEx                            Your Internal Model
+──────────────────────────────────────────────────────
+Line + Route                 →   "Route" or "Line"
+JourneyPattern               →   "Stop sequence"
+ServiceJourney               →   "Trip" or "Departure"
+StopPlace + Quay             →   "Stop" (flattened or hierarchical?)
+DayType + OperatingPeriod    →   "Schedule" or "Calendar"
+PreassignedFareProduct       →   "Ticket type" or "Product"
+```
+
+Key decisions you will face:
+
+1. **Flatten or preserve hierarchy?** NeTEx separates Line → Route → JourneyPattern → ServiceJourney. You may want to flatten some levels, but consider whether you lose useful distinctions.
+
+2. **Store references or denormalize?** NeTEx uses `*Ref` links everywhere. You can resolve them at import time (denormalize) or store them as foreign keys.
+
+3. **Merge or keep profiles separate?** If you ingest from multiple sources using different profiles, decide whether to normalize to a common model or preserve source-specific fields.
+
+> ⚠️ **Note:** Do not flatten the hierarchy prematurely. The separation exists for good reasons (see [Separation of Concerns](../SeparationOfConcerns/SeparationOfConcerns.md)). If you merge Line and Route at import, you lose the ability to model routes that share the same line.
+
+---
+
+## 8. 📡 Relationship to SIRI for Real-Time
+
+NeTEx provides **planned data** (what should happen). SIRI provides **real-time data** (what is actually happening). Both are built on Transmodel, so their references are compatible:
+
+```text
+NeTEx (planned)                      SIRI (real-time)
+──────────────────────────────────────────────────────────
+ServiceJourney (id: "SJ_001")    ←→  MonitoredVehicleJourney (ref: "SJ_001")
+StopPlace (id: "SP_100")         ←→  MonitoredStopVisit (ref: "SP_100")
+Line (id: "L1")                  ←→  LineRef (ref: "L1")
+```
+
+A MaaS platform typically loads NeTEx as the baseline dataset, then overlays SIRI updates for delays, cancellations, and real-time vehicle positions. The shared ID scheme means you can join planned and real-time data directly.
+
+---
+
+## 9. ✅ Best Practices
+
+1. **Build a reference resolver.** Create an ID lookup map during parsing so `*Ref` elements can be resolved efficiently.
+2. **Parse frame-first.** Walk the CompositeFrame and process each frame in domain order (ResourceFrame first, then SiteFrame, then ServiceFrame, etc.).
+3. **Tolerate missing elements.** Never assume an optional element is present. Use defaults or null-safe patterns.
+4. **Track versions.** Use the `version` attribute on objects to detect changes between deliveries.
+5. **Validate incoming data.** Even as a consumer, running schema validation on received deliveries catches upstream errors early.
+6. **Keep NeTEx IDs.** Store the original NeTEx `id` alongside your internal ID to maintain traceability back to the source.
+
+---
+
+## 10. 🔗 Related Resources
+
+### Guides
+- [Get Started](../GetStarted/GetStarted_Guide.md) — Document structure and NeTEx basics
+- [Decision Makers](../DecisionMakers/DecisionMakers_Guide.md) — NeTEx overview and profile comparison
+- [Separation of Concerns](../SeparationOfConcerns/SeparationOfConcerns.md) — Why frames exist and how domains interact
+- [Fare Modelling](../FareModelling/FareModelling_Guide.md) — Fare product hierarchy
+- [Journey Lifecycle](../JourneyLifecycle/JourneyLifecycle_Guide.md) — The core data chain
+- [Interchange](../InterchangeOnly/Interchange_Guide.md) — Transfer and connection modelling
+
+### External
+- [NeTEx CEN Standard](https://www.netex-cen.eu/) — Official specification
+- [SIRI CEN Standard](https://www.siri-cen.eu/) — Real-time companion standard
+- [Transmodel](https://www.transmodel-cen.eu/) — The underlying conceptual model

--- a/Guides/RegulatoryCompliance/RegulatoryCompliance_Guide.md
+++ b/Guides/RegulatoryCompliance/RegulatoryCompliance_Guide.md
@@ -1,0 +1,146 @@
+# 📜 Regulatory Compliance — Delegated Regulation & NAP Submission
+
+## 1. 🎯 Introduction
+
+EU Delegated Regulation 2017/1926 requires public transport authorities and operators across Europe to provide scheduled transport data through National Access Points (NAPs). For a local or regional bus operator this can feel overwhelming — the regulation references broad data categories, and NeTEx is a large standard. This guide cuts through the complexity and maps the regulatory requirements to concrete NeTEx objects you need to produce.
+
+In this guide you will learn:
+- 📋 What data categories the Delegated Regulation requires
+- 🏗️ How EPIP and the Nordic Profile relate to the regulation
+- 📐 Which NeTEx frames and objects map to each requirement
+- 🚌 A step-by-step checklist for a bus operator's minimum dataset
+- 🌐 How NAP submission works in practice
+
+---
+
+## 2. 📋 What the Delegated Regulation Requires
+
+Delegated Regulation 2017/1926 on Multimodal Travel Information Services defines data categories that EU member states must make available, grouped by implementation priority:
+
+| Priority | Deadline | Data Categories | NeTEx Coverage |
+|----------|----------|-----------------|----------------|
+| **A** | Dec 2019 | Stop/station location, routes, timetables, accessibility | StopPlace, Line, ServiceJourney, AccessibilityAssessment |
+| **B** | Dec 2021 | Fares, on-demand transport, trip plans | FareProduct, FlexibleServiceProperties, SalesOfferPackage |
+| **C** | Dec 2023 | Disruptions, real-time, availability | Primarily SIRI (not NeTEx) |
+
+Category C is mostly SIRI territory (real-time updates, disruptions). This guide focuses on NeTEx deliveries for categories A and B.
+
+> 💡 **Tip:** Most bus operators start with Priority A data — stops, lines, timetables, and accessibility. This alone satisfies the core compliance requirement.
+
+---
+
+## 3. 🏗️ EPIP vs Nordic Profile
+
+The Delegated Regulation does not mandate NeTEx directly — it requires data to be available in a standard format. In practice, EPIP (European Passenger Information Profile) is the EU-level NeTEx profile for cross-border exchange, and national profiles build on top of it.
+
+| Aspect | EPIP (EU baseline) | Nordic Profile |
+|--------|---------------------|----------------|
+| Scope | Minimum for cross-border exchange | Full national dataset |
+| StopPlace | Basic: Name, Location | + Quay, AccessibilityAssessment, Equipment |
+| Governance | Authority, Operator | + ResponsibilitySet, Contract |
+| Accessibility | Recommended | Mandatory at StopPlace and Quay level |
+| Fares | Basic structure | Full product hierarchy |
+
+> ⚠️ **Note:** EPIP is the legal minimum. National authorities typically require the national profile (e.g. Nordic Profile), which is stricter. Always check your NAP's specific requirements.
+
+See the [Decision Makers](../DecisionMakers/DecisionMakers_Guide.md) guide (section 4) for a broader regulatory context overview.
+
+---
+
+## 4. 📐 Mapping Requirements to NeTEx
+
+The table below maps each regulation requirement to the NeTEx frame and objects you need, with links to the guide that covers each topic in detail:
+
+| Regulation Requirement | NeTEx Frame | Key Objects | Guide |
+|------------------------|-------------|-------------|-------|
+| Who operates | ResourceFrame | Authority, Operator, ResponsibilitySet | [OrganisationalGovernance](../OrganisationalGovernance/OrganisationalGovernance_Guide.md) |
+| Where services stop | SiteFrame | StopPlace, Quay, PassengerStopAssignment | [StopInfrastructure](../StopInfrastructure/StopInfrastructure_Guide.md) |
+| When services run | ServiceCalendarFrame | DayType, OperatingPeriod | [JourneyLifecycle](../JourneyLifecycle/JourneyLifecycle_Guide.md) |
+| What services exist | ServiceFrame | Line, Route, JourneyPattern | [JourneyLifecycle](../JourneyLifecycle/JourneyLifecycle_Guide.md) |
+| Timetables | TimetableFrame | ServiceJourney, TimetabledPassingTime | [JourneyLifecycle](../JourneyLifecycle/JourneyLifecycle_Guide.md) |
+| Accessibility | SiteFrame | AccessibilityAssessment, AccessibilityLimitation | [Accessibility](../Accessibility/Accessibility_Guide.md) |
+| Fares (Priority B) | FareFrame | TariffZone, PreassignedFareProduct, SalesOfferPackage | [FareModelling](../FareModelling/FareModelling_Guide.md) |
+
+The minimum compliant delivery for Priority A looks like this:
+
+```text
+PublicationDelivery
+ └── CompositeFrame
+      ├── ResourceFrame ........... Authority + Operator
+      ├── SiteFrame ............... StopPlace + Quay + Accessibility
+      ├── ServiceCalendarFrame .... DayType
+      ├── ServiceFrame ............ Line + Route + JourneyPattern
+      └── TimetableFrame .......... ServiceJourney + passing times
+```
+
+---
+
+## 5. 🚌 What a Bus Operator Needs to Produce
+
+Follow these steps to build a compliant dataset. Each step links to the guide that walks you through it:
+
+1. **Define your organisation** — Create Authority and Operator in a ResourceFrame. See [OrganisationalGovernance](../OrganisationalGovernance/OrganisationalGovernance_Guide.md).
+
+2. **Register your stops** — Model each stop as a StopPlace with Quays in a SiteFrame. Add an AccessibilityAssessment to each. See [StopInfrastructure](../StopInfrastructure/StopInfrastructure_Guide.md) and [Accessibility](../Accessibility/Accessibility_Guide.md).
+
+3. **Define your calendar** — Create DayTypes for weekdays, weekends, and holidays in a ServiceCalendarFrame. See [JourneyLifecycle](../JourneyLifecycle/JourneyLifecycle_Guide.md).
+
+4. **Model your network** — Define Line, Route, and JourneyPattern in a ServiceFrame. See [JourneyLifecycle](../JourneyLifecycle/JourneyLifecycle_Guide.md).
+
+5. **Build your timetable** — Create ServiceJourneys with TimetabledPassingTimes in a TimetableFrame. See [JourneyLifecycle](../JourneyLifecycle/JourneyLifecycle_Guide.md).
+
+6. **Validate against the schema** — Run XSD validation and profile checks before submission. See [Validation](../Validation/Validation.md).
+
+7. **Submit to your NAP** — Package and upload your delivery (see next section).
+
+> 💡 **Tip:** You do not need to produce everything at once. Start with stops and the network (steps 1–4), then add timetables. This gives you a valid, useful dataset even before the full production chain is complete.
+
+See [Get Started](../GetStarted/GetStarted_Guide.md) for the basics of NeTEx document structure.
+
+---
+
+## 6. 🌐 NAP Submission Workflow
+
+A National Access Point (NAP) is a national portal where transport data is published and made available to multimodal journey planners. Each EU member state operates its own NAP (e.g. data.entur.no in Norway, BODS in the UK, transport.data.gouv.fr in France).
+
+The general submission workflow:
+
+```text
+1. PRODUCE          2. VALIDATE           3. SUBMIT          4. PUBLISH
+   NeTEx XML   -->    Schema + Profile   -->  NAP portal   -->  Available to
+                      validation               or API           journey planners
+```
+
+Validation is critical before submission — invalid data may be rejected outright or cause downstream errors in journey planners. Some NAPs accept only specific profiles, so check your NAP's documentation for format and profile requirements.
+
+> ⚠️ **Note:** NAP submission processes vary significantly between countries. This guide covers the general workflow; consult your national NAP documentation for specific requirements, APIs, and delivery schedules.
+
+---
+
+## 7. ✅ Best Practices
+
+1. **Start with Priority A data.** Stops, lines, timetables, and accessibility cover the core regulatory requirement and deliver immediate value.
+2. **Validate early and often.** Run schema validation after every change, not just before submission. See [Validation](../Validation/Validation.md).
+3. **Use the profile's cardinality rules.** Do not omit mandatory elements — the NAP will likely reject incomplete data.
+4. **Version your data.** Every object should carry a `version` attribute so downstream systems can detect changes.
+5. **Reuse existing stop registries.** Do not create duplicate StopPlace IDs if your country has a national stop registry (e.g. NSR in Norway).
+6. **Follow the existing guides.** Each step in the production chain is documented in detail in a dedicated guide — use them rather than reinventing the structure.
+
+---
+
+## 8. 🔗 Related Resources
+
+### Guides
+- [Get Started](../GetStarted/GetStarted_Guide.md) — Introduction to NeTEx document structure
+- [Journey Lifecycle](../JourneyLifecycle/JourneyLifecycle_Guide.md) — The core data chain from Line to ServiceJourney
+- [Stop Infrastructure](../StopInfrastructure/StopInfrastructure_Guide.md) — StopPlace, Quay, and PassengerStopAssignment
+- [Accessibility](../Accessibility/Accessibility_Guide.md) — AccessibilityAssessment and equipment
+- [Organisational Governance](../OrganisationalGovernance/OrganisationalGovernance_Guide.md) — Authority, Operator, and ResponsibilitySet
+- [Fare Modelling](../FareModelling/FareModelling_Guide.md) — Products, zones, and tariffs (Priority B)
+- [Validation](../Validation/Validation.md) — Schema validation and common errors
+- [Decision Makers](../DecisionMakers/DecisionMakers_Guide.md) — NeTEx overview and regulatory context
+
+### External
+- [EU Delegated Regulation 2017/1926](https://eur-lex.europa.eu/eli/reg_del/2017/1926/oj) — Full legal text
+- [NeTEx CEN Standard](https://www.netex-cen.eu/) — Official specification
+- [EPIP Documentation](https://netex-cen.eu/?page_id=29) — European Passenger Information Profile

--- a/LLM/Tables/TableOfContent.md
+++ b/LLM/Tables/TableOfContent.md
@@ -18,6 +18,8 @@ How-to guides, conceptual overviews, and reference material:
 - [Accessibility](../../Guides/Accessibility/Accessibility_Guide.md) – AccessibilityAssessment, equipment, and indoor navigation paths
 - [FareModelling](../../Guides/FareModelling/FareModelling_Guide.md) – Products, zones, tariffs, and sales offer packages
 - [DecisionMakers](../../Guides/DecisionMakers/DecisionMakers_Guide.md) – NeTEx overview for decision makers and stakeholders
+- [RegulatoryCompliance](../../Guides/RegulatoryCompliance/RegulatoryCompliance_Guide.md) – Delegated Regulation 2017/1926 requirements and NAP submission
+- [MaaSConsumers](../../Guides/MaaSConsumers/MaaSConsumers_Guide.md) – Consuming NeTEx datasets as a MaaS platform
 - [Glossary](../../Guides/Glossary/) – Terminology and definitions
 
 ## Frames

--- a/README.md
+++ b/README.md
@@ -70,6 +70,8 @@ Each guide lives in its own folder under [`Guides/`](Guides/) and can include su
 | [Accessibility](Guides/Accessibility/Accessibility_Guide.md) | AccessibilityAssessment, equipment, and indoor navigation paths |
 | [FareModelling](Guides/FareModelling/FareModelling_Guide.md) | Products, zones, tariffs, and sales offer packages |
 | [DecisionMakers](Guides/DecisionMakers/DecisionMakers_Guide.md) | NeTEx overview for decision makers and stakeholders |
+| [RegulatoryCompliance](Guides/RegulatoryCompliance/RegulatoryCompliance_Guide.md) | Delegated Regulation 2017/1926 requirements and NAP submission |
+| [MaaSConsumers](Guides/MaaSConsumers/MaaSConsumers_Guide.md) | Consuming NeTEx datasets as a MaaS platform |
 | [Glossary](Guides/Glossary/) | Terminology and definitions |
 
 ---


### PR DESCRIPTION
## Summary
- **RegulatoryCompliance guide**: Walks local/regional bus operators through EU Delegated Regulation 2017/1926 requirements, maps data categories to NeTEx frames/objects, includes a 7-step production checklist and NAP submission workflow
- **MaaSConsumers guide**: Consumer-oriented guide covering parsing strategies (frame-first vs object-first), key objects for MaaS platforms, handling profiles and missing data, NeTEx-to-internal-model mapping, and the SIRI relationship
- Updated TableOfContent.md and README.md with both new entries

## Test plan
- [ ] Verify all cross-reference links in both guides resolve correctly
- [ ] Confirm both guides appear in TableOfContent.md and README.md
- [ ] Review guide content for accuracy against NeTEx standard

?? Generated with [Claude Code](https://claude.com/claude-code)