### PR TITLE
Expand Glossary with NeTEx XSD and Transmodel definitions

### DIFF
--- a/Guides/Glossary/Glossary.md
+++ b/Guides/Glossary/Glossary.md
@@ -1,18 +1,365 @@
 # Glossary
 
+Core terms used in this NeTEx profile, organised alphabetically.
+Each entry gives a short definition and a link to the full documentation.
+
+<!-- entur-terms-ready: format maps to SKOS prefLabel + definition -->
+
+---
+
+## AlternativeName
+
+Additional name variant for a NeTEx object - such as an official registration, translation, or abbreviation.
+
+→ [Full documentation](../../Objects/AlternativeName/Description_AlternativeName.md)
+
+---
+
+## AlternativeText
+
+Supplementary textual description attached to any NeTEx object.
+
+→ [Full documentation](../../Objects/AlternativeText/Description_AlternativeText.md)
+
+---
+
+## Authority
+
+A public transport organisation responsible for planning, organising, and managing public transport services within a specific geographical area.
+
+→ [Full documentation](../../Objects/Authority/Description_Authority.md)
+
+---
+
+## Codespace
+
+The namespace definition used for all NeTEx `@id` and `@ref` values within a dataset, ensuring identifier uniqueness across producers.
+
+→ [Full documentation](../../Objects/Codespace/Description_Codespace.md)
+
+---
+
+## CompositeFrame
+
+A container frame that groups multiple typed frames (ServiceFrame, TimetableFrame, etc.) into a single coherent delivery.
+
+→ [Full documentation](../../Frames/CompositeFrame/Description_CompositeFrame.md)
+
+---
+
+## Contract
+
+A legal or commercial agreement governing responsibilities between an Authority (contractee) and an Operator (contractor) for providing public transport services.
+
+→ [Full documentation](../../Objects/Contract/Description_Contract.md)
+
+---
+
+## DatedServiceJourney
+
+A specific operational instance of a ServiceJourney on a particular calendar day, including day-specific modifications such as cancellations, replacements, or reinforcements.
+
+→ [Full documentation](../../Objects/DatedServiceJourney/Description_DatedServiceJourney.md)
+
+---
+
+## DayType
+
+A classification of days on which a specific set of transport services operates (e.g., "Weekdays", "Saturdays", "Public Holidays").
+
+→ [Full documentation](../../Objects/DayType/Description_DayType.md)
+
+---
+
+## DayTypeAssignment
+
+The binding between a DayType and a specific date or date range (OperatingPeriod), determining when that DayType is active - including exception handling via `isAvailable=false`.
+
+→ [Full documentation](../../Objects/DayTypeAssignment/Description_DayTypeAssignment.md)
+
+---
+
+## DestinationDisplay
+
+The text shown on the front or side of a public transport vehicle to indicate its destination, including via-points and variant labels.
+
+→ [Full documentation](../../Objects/DestinationDisplay/Description_DestinationDisplay.md)
+
+---
+
+## FareContract
+
+A customer-facing agreement for the right to travel and consume fare products, defined within a SalesTransactionFrame (NeTEx Part 3 - Sales).
+
+→ [Full documentation](../../Objects/FareContract/Description_FareContract.md)
+
+---
+
+## FareZone
+
+A geographic zone used to determine ticket prices in public transport, grouping stop points for fare calculation.
+
+→ [Full documentation](../../Objects/FareZone/Description_FareZone.md)
+
+---
+
+## FlexibleServiceProperties
+
+The scheduling and operational characteristics of a flexible (demand-responsive) transport service, attached to a ServiceJourney.
+
+→ [Full documentation](../../Objects/FlexibleServiceProperties/Description_FlexibleServiceProperties.md)
+
+---
+
+## GroupOfLines
+
+A logical grouping of multiple Line objects for common management, branding, distribution, or filtering.
+
+→ [Full documentation](../../Objects/GroupOfLines/Description_GroupOfLines.md)
+
+---
+
+## Interchange
+
+A planned transfer opportunity between two ServiceJourneys at a shared stop point, modelled as `ServiceJourneyInterchange` in XML.
+
+→ [Full documentation](../../Objects/Interchange/Description_Interchange.md)
+
+---
+
+## JourneyPattern
+
+The ordered sequence of ScheduledStopPoints that a transport service follows for a specific variant of a Route.
+
+→ [Full documentation](../../Objects/JourneyPattern/Description_JourneyPattern.md)
+
+---
+
+## Line
+
+A public transport service line, representing a marketed route with a name, transport mode, and operator.
+
+→ [Full documentation](../../Objects/Line/Description_Line.md)
+
+---
+
+## LinkSequenceProjection
+
+The geographic representation of a ServiceLink, carrying GML geometry (typically a LineString) describing the spatial path between two consecutive ScheduledStopPoints.
+
+→ [Full documentation](../../Objects/LinkSequenceProjection/Description_LinkSequenceProjection.md)
+
+---
+
+## Notice
+
+Informational or regulatory text associated with public transport services, displayed to passengers.
+
+→ [Full documentation](../../Objects/Notice/Description_Notice.md)
+
+---
+
+## OperatingDay
+
+A specific calendar date on which transport services operate, referenced by DatedServiceJourney to anchor a journey to a concrete day.
+
+→ [Full documentation](../../Objects/OperatingDay/Description_OperatingDay.md)
+
+---
+
+## OperatingPeriod
+
+A continuous date range (FromDate-ToDate) during which a set of transport services may operate, used by DayTypeAssignment.
+
+→ [Full documentation](../../Objects/OperatingPeriod/Description_OperatingPeriod.md)
+
+---
+
+## Operator
+
+An organisation that provides public transport services under contract with an Authority.
+
+→ [Full documentation](../../Objects/Operator/Description_Operator.md)
+
+---
+
+## Parking
+
+A parking facility associated with public transport - such as a park-and-ride lot, bike parking, or car park at a station.
+
+→ [Full documentation](../../Objects/Parking/Description_Parking.md)
+
+---
+
+## PassengerStopAssignment
+
+The bridge linking a logical ScheduledStopPoint to a physical Quay within a StopPlace, connecting timetable planning with physical infrastructure.
+
+→ [Full documentation](../../Objects/PassengerStopAssignment/Description_PassengerStopAssignment.md)
+
+---
+
+## placeEquipments
+
+A container within a StopPlace or Quay holding equipment items (shelters, waiting rooms, sanitary facilities, ticketing machines) that describe the physical amenities at the stop.
+
+→ [Full documentation](../../Objects/placeEquipments/Description_placeEquipments.md)
+
+---
+
+## PublicationDelivery
+
+The root element of every NeTEx XML document, wrapping one or more frames with metadata (timestamp, participant, description).
+
+→ [Example](../../Frames/Example_PublicationDelivery.xml)
+
+---
+
+## PurposeOfGrouping
+
+A classifier for the reason why NeTEx objects are grouped together (e.g., for presentation, regulation, or contract scope).
+
+→ [Full documentation](../../Objects/PurposeOfGrouping/Description_PurposeOfGrouping.md)
+
+---
+
+## Quay
+
+A specific boarding or alighting position (platform, stand, bay) within a StopPlace where passengers physically meet vehicles.
+
+→ [Full documentation](../../Objects/Quay/Description_Quay.md)
+
+---
+
+## ResponsibilitySet
+
+The set of roles and organisations responsible for managing data, operations, or contractual obligations within a defined scope.
+
+→ [Full documentation](../../Objects/ResponsibilitySet/Description_ResponsibilitySet.md)
+
+---
+
+## Route
+
+The logical geographic path definition for a Line with a specific direction.
+
+→ [Full documentation](../../Objects/Route/Description_Route.md)
+
+---
+
+## SanitaryEquipment
+
+Sanitary facilities (toilets, washrooms) available at a stop place, station, or onboard a vehicle.
+
+→ [Full documentation](../../Objects/SanitaryEquipment/Description_SanitaryEquipment.md)
+
+---
+
+## ScheduledStopPoint
+
+A logical stopping point in the timetable, used by JourneyPatterns and ServiceJourneys to define where vehicles stop.
+
+→ [Full documentation](../../Objects/ScheduledStopPoint/Description_ScheduledStopPoint.md)
+
+---
+
+## ServiceAlteration
+
+An enumeration on DatedServiceJourney indicating the deviation type. Allowed values: `planned`, `cancellation`, `replaced`, `extraJourney`. Omitted implies `planned`.
+
+→ [DatedServiceJourney table](../../Objects/DatedServiceJourney/Table_DatedServiceJourney.md)
+
+---
+
+## ServiceJourney
+
+A planned trip in the timetable operating on a recurring schedule, defining the stop sequence via a JourneyPattern, passing times, operator, and days of operation.
+
+→ [Full documentation](../../Objects/ServiceJourney/Description_ServiceJourney.md)
+
+---
+
+## ShelterEquipment
+
+Weather shelter facilities available at a stop place or quay, with properties such as seating, step-free access, and enclosure.
+
+→ [Full documentation](../../Objects/ShelterEquipment/Description_ShelterEquipment.md)
+
+---
+
+## StopPlace
+
+A named physical or virtual location where passengers can board or alight from public transport, containing one or more Quays.
+
+→ [Full documentation](../../Objects/StopPlace/Description_StopPlace.md)
+
+---
+
+## TariffZone
+
+A geographic fare zone used for ticketing and pricing, grouping stops and areas into zones that determine ticket prices.
+
+→ [Full documentation](../../Objects/TariffZone/Description_TariffZone.md)
+
+---
+
+## TicketingEquipment
+
+Ticket machines, validators, or other ticketing infrastructure available at a stop place or station.
+
+→ [Full documentation](../../Objects/TicketingEquipment/Description_TicketingEquipment.md)
+
+---
+
+## TopographicPlace
+
+A named geographic area such as a city, municipality, county, or region - used to provide spatial context for StopPlaces.
+
+→ [Full documentation](../../Objects/TopographicPlace/Description_TopographicPlace.md)
+
+---
+
+## TrainBlock
+
+A rail-specific specialisation of Block that represents an operational grouping for a single train on a given operating day.
+
+→ [Full documentation](../../Objects/TrainBlock/Description_TrainBlock.md)
+
+---
+
+## Vehicle
+
+A specific physical vehicle in the fleet used to operate public transport services.
+
+→ [Full documentation](../../Objects/Vehicle/Description_Vehicle.md)
+
+---
+
+## VehicleType
+
+A typified vehicle configuration (model or series) defining reusable characteristics such as capacity, dimensions, propulsion, and accessibility features.
+
+→ [Full documentation](../../Objects/VehicleType/Description_VehicleType.md)
+
+---
+
 ## View
 
-Definition
-- In this profile, the term “View” is used in two complementary senses:
-  1) Publication view: The way data is selected and packaged inside a NeTEx PublicationDelivery for a specific purpose or audience (for example, a Timetable publication view or a Network publication view).
-  2) Thematic view: A conceptual grouping used in the profile to scope content and requirements (for example, Timetable, Network, Fares). It helps readers navigate the documentation but does not imply a distinct NeTEx structure on its own.
+In this profile, "View" is used in two complementary senses:
 
-Clarifications
-- DatedCalls are not a separate “view”. They are child elements of a DatedServiceJourney within a TimetableFrame and describe the stop-by-stop call sequence for a specific operating day.
-- DatedServiceJourney and its DatedCalls belong to the Timetable publication view. In practice, they appear in a PublicationDelivery that contains a TimetableFrame.
+1. **Publication view** - The way data is selected and packaged inside a NeTEx PublicationDelivery for a specific purpose or audience (e.g., a Timetable publication view).
+2. **Thematic view** - A conceptual grouping used in the profile to scope content and requirements (e.g., Timetable, Network, Fares).
 
-Notes
-- The “view” wording is purely to reduce ambiguity in documentation. When in doubt, prefer the precise NeTEx model terms (e.g., PublicationDelivery, TimetableFrame, DatedServiceJourney, DatedCalls).
+Clarifications:
+- DatedCalls are not a separate "view" - they are child elements of a DatedServiceJourney within a TimetableFrame.
+- When in doubt, prefer the precise NeTEx model terms (PublicationDelivery, TimetableFrame, DatedServiceJourney).
 
-See also
-- Objects/DatedServiceJourney (profile object documentation)
+→ [DatedServiceJourney](../../Objects/DatedServiceJourney/Description_DatedServiceJourney.md)
+
+---
+
+## WaitingRoomEquipment
+
+Enclosed indoor waiting room facilities available at a stop place or station, with properties such as seating, step-free access, and heating.
+
+→ [Full documentation](../../Objects/WaitingRoomEquipment/Description_WaitingRoomEquipment.md)

--- a/Guides/Glossary/Glossary.md
+++ b/Guides/Glossary/Glossary.md
@@ -11,6 +11,8 @@ Each entry gives a short definition and a link to the full documentation.
 
 Additional name variant for a NeTEx object - such as an official registration, translation, or abbreviation.
 
+> **NeTEx XSD:** Alternative Name.
+
 → [Full documentation](../../Objects/AlternativeName/Description_AlternativeName.md)
 
 ---
@@ -18,6 +20,8 @@ Additional name variant for a NeTEx object - such as an official registration, t
 ## AlternativeText
 
 Supplementary textual description attached to any NeTEx object.
+
+> **NeTEx XSD:** Alternative Text.
 
 → [Full documentation](../../Objects/AlternativeText/Description_AlternativeText.md)
 
@@ -27,6 +31,8 @@ Supplementary textual description attached to any NeTEx object.
 
 A public transport organisation responsible for planning, organising, and managing public transport services within a specific geographical area.
 
+> **NeTEx XSD:** The ORGANISATION under which the responsibility of organising the transport service in a certain area is placed.
+
 → [Full documentation](../../Objects/Authority/Description_Authority.md)
 
 ---
@@ -34,6 +40,8 @@ A public transport organisation responsible for planning, organising, and managi
 ## Codespace
 
 The namespace definition used for all NeTEx `@id` and `@ref` values within a dataset, ensuring identifier uniqueness across producers.
+
+> **NeTEx XSD:** A system for uniquely identifying objects of a given type. Used for the distributed management of objects from many different sources.
 
 → [Full documentation](../../Objects/Codespace/Description_Codespace.md)
 
@@ -43,6 +51,8 @@ The namespace definition used for all NeTEx `@id` and `@ref` values within a dat
 
 A container frame that groups multiple typed frames (ServiceFrame, TimetableFrame, etc.) into a single coherent delivery.
 
+> **NeTEx XSD:** A container VERSION FRAME that groups a set of content VERSION FRAMEs to which the same VALIDITY CONDITIONs have been assigned.
+
 → [Full documentation](../../Frames/CompositeFrame/Description_CompositeFrame.md)
 
 ---
@@ -50,6 +60,8 @@ A container frame that groups multiple typed frames (ServiceFrame, TimetableFram
 ## Contract
 
 A legal or commercial agreement governing responsibilities between an Authority (contractee) and an Operator (contractor) for providing public transport services.
+
+> **NeTEx XSD:** A CONTRACT between ORGANISATIONs to supply services or goods.
 
 → [Full documentation](../../Objects/Contract/Description_Contract.md)
 
@@ -59,13 +71,17 @@ A legal or commercial agreement governing responsibilities between an Authority 
 
 A specific operational instance of a ServiceJourney on a particular calendar day, including day-specific modifications such as cancellations, replacements, or reinforcements.
 
+> **NeTEx XSD:** A particular SERVICE JOURNEY of a vehicle on a particular OPERATING DAY including all modifications possibly decided by the control staff.
+
 → [Full documentation](../../Objects/DatedServiceJourney/Description_DatedServiceJourney.md)
 
 ---
 
 ## DayType
 
-A classification of days on which a specific set of transport services operates (e.g., "Weekdays", "Saturdays", "Public Holidays").
+A classification of days on which a specific set of transport services operates (e.g., Weekdays, Saturdays, Public Holidays).
+
+> **NeTEx XSD:** A type of day characterized by one or more properties which affect public transport operation. For example: weekday in school holidays.
 
 → [Full documentation](../../Objects/DayType/Description_DayType.md)
 
@@ -75,6 +91,8 @@ A classification of days on which a specific set of transport services operates 
 
 The binding between a DayType and a specific date or date range (OperatingPeriod), determining when that DayType is active - including exception handling via `isAvailable=false`.
 
+> **NeTEx XSD:** Associates a DAY TYPE with an OPERATING DAY within a specific Calendar. A specification of a particular DAY TYPE which will be valid during a TIME BAND on an OPERATING DAY.
+
 → [Full documentation](../../Objects/DayTypeAssignment/Description_DayTypeAssignment.md)
 
 ---
@@ -82,6 +100,8 @@ The binding between a DayType and a specific date or date range (OperatingPeriod
 ## DestinationDisplay
 
 The text shown on the front or side of a public transport vehicle to indicate its destination, including via-points and variant labels.
+
+> **NeTEx XSD:** An advertised destination of a specific JOURNEY PATTERN, usually displayed on a head sign or at other on-board locations.
 
 → [Full documentation](../../Objects/DestinationDisplay/Description_DestinationDisplay.md)
 
@@ -91,6 +111,8 @@ The text shown on the front or side of a public transport vehicle to indicate it
 
 A customer-facing agreement for the right to travel and consume fare products, defined within a SalesTransactionFrame (NeTEx Part 3 - Sales).
 
+> **NeTEx XSD:** A contract with a particular (but possibly anonymous) customer, ruling the consumption of transport services (and joint services). A FARE CONTRACT may be designed for a fixed SALES OFFER PACKAGE (e.g. ticket) or to allow successive purchases of SALES OFFER PACKAGEs.
+
 → [Full documentation](../../Objects/FareContract/Description_FareContract.md)
 
 ---
@@ -98,6 +120,8 @@ A customer-facing agreement for the right to travel and consume fare products, d
 ## FareZone
 
 A geographic zone used to determine ticket prices in public transport, grouping stop points for fare calculation.
+
+> **NeTEx XSD:** A specialization of TARIFF ZONE to include FARE SECTIONs.
 
 → [Full documentation](../../Objects/FareZone/Description_FareZone.md)
 
@@ -107,6 +131,8 @@ A geographic zone used to determine ticket prices in public transport, grouping 
 
 The scheduling and operational characteristics of a flexible (demand-responsive) transport service, attached to a ServiceJourney.
 
+> **NeTEx XSD:** FLEXIBLE SERVICE PROPERTIES in frame.
+
 → [Full documentation](../../Objects/FlexibleServiceProperties/Description_FlexibleServiceProperties.md)
 
 ---
@@ -114,6 +140,8 @@ The scheduling and operational characteristics of a flexible (demand-responsive)
 ## GroupOfLines
 
 A logical grouping of multiple Line objects for common management, branding, distribution, or filtering.
+
+> **NeTEx XSD:** A grouping of LINEs which will be commonly referenced for a specific purpose.
 
 → [Full documentation](../../Objects/GroupOfLines/Description_GroupOfLines.md)
 
@@ -123,6 +151,8 @@ A logical grouping of multiple Line objects for common management, branding, dis
 
 A planned transfer opportunity between two ServiceJourneys at a shared stop point, modelled as `ServiceJourneyInterchange` in XML.
 
+> **NeTEx XSD:** The scheduled possibility for transfer of passengers between two SERVICE JOURNEYs at the same or different STOP POINTs.
+
 → [Full documentation](../../Objects/Interchange/Description_Interchange.md)
 
 ---
@@ -130,6 +160,8 @@ A planned transfer opportunity between two ServiceJourneys at a shared stop poin
 ## JourneyPattern
 
 The ordered sequence of ScheduledStopPoints that a transport service follows for a specific variant of a Route.
+
+> **NeTEx XSD:** An ordered list of SCHEDULED STOP POINTs and TIMING POINTs on a single ROUTE, describing the pattern of working for public transport vehicles. A JOURNEY PATTERN may pass through the same POINT more than once. The first point of a JOURNEY PATTERN is the origin. The last point is the destination.
 
 → [Full documentation](../../Objects/JourneyPattern/Description_JourneyPattern.md)
 
@@ -139,6 +171,8 @@ The ordered sequence of ScheduledStopPoints that a transport service follows for
 
 A public transport service line, representing a marketed route with a name, transport mode, and operator.
 
+> **NeTEx XSD:** A group of ROUTEs which is generally known to the public by a similar name or number.
+
 → [Full documentation](../../Objects/Line/Description_Line.md)
 
 ---
@@ -146,6 +180,8 @@ A public transport service line, representing a marketed route with a name, tran
 ## LinkSequenceProjection
 
 The geographic representation of a ServiceLink, carrying GML geometry (typically a LineString) describing the spatial path between two consecutive ScheduledStopPoints.
+
+> **NeTEx XSD:** A Projection of a whole LINK SEQUENCE as an ordered series of POINTs.
 
 → [Full documentation](../../Objects/LinkSequenceProjection/Description_LinkSequenceProjection.md)
 
@@ -155,6 +191,8 @@ The geographic representation of a ServiceLink, carrying GML geometry (typically
 
 Informational or regulatory text associated with public transport services, displayed to passengers.
 
+> **NeTEx XSD:** A note or footnote about any aspect of a service, e.g. an announcement, notice, etc. May have different DELIVERY VARIANTs for different media.
+
 → [Full documentation](../../Objects/Notice/Description_Notice.md)
 
 ---
@@ -162,6 +200,8 @@ Informational or regulatory text associated with public transport services, disp
 ## OperatingDay
 
 A specific calendar date on which transport services operate, referenced by DatedServiceJourney to anchor a journey to a concrete day.
+
+> **NeTEx XSD:** A day of public transport operation in a specific calendar. An OPERATING DAY may last more than 24 hours.
 
 → [Full documentation](../../Objects/OperatingDay/Description_OperatingDay.md)
 
@@ -171,6 +211,8 @@ A specific calendar date on which transport services operate, referenced by Date
 
 A continuous date range (FromDate-ToDate) during which a set of transport services may operate, used by DayTypeAssignment.
 
+> **NeTEx XSD:** A continuous interval of time between two OPERATING DAYs which will be used to define validities.
+
 → [Full documentation](../../Objects/OperatingPeriod/Description_OperatingPeriod.md)
 
 ---
@@ -178,6 +220,8 @@ A continuous date range (FromDate-ToDate) during which a set of transport servic
 ## Operator
 
 An organisation that provides public transport services under contract with an Authority.
+
+> **NeTEx XSD:** A company providing public transport services.
 
 → [Full documentation](../../Objects/Operator/Description_Operator.md)
 
@@ -187,6 +231,8 @@ An organisation that provides public transport services under contract with an A
 
 A parking facility associated with public transport - such as a park-and-ride lot, bike parking, or car park at a station.
 
+> **NeTEx XSD:** A named place where Parking may be accessed. May be a building complex (e.g. a station) or an on-street location.
+
 → [Full documentation](../../Objects/Parking/Description_Parking.md)
 
 ---
@@ -194,6 +240,8 @@ A parking facility associated with public transport - such as a park-and-ride lo
 ## PassengerStopAssignment
 
 The bridge linking a logical ScheduledStopPoint to a physical Quay within a StopPlace, connecting timetable planning with physical infrastructure.
+
+> **NeTEx XSD:** The default allocation of a SCHEDULED STOP POINT to a specific STOP PLACE, and also possibly a QUAY and BOARDING POSITION.
 
 → [Full documentation](../../Objects/PassengerStopAssignment/Description_PassengerStopAssignment.md)
 
@@ -211,6 +259,8 @@ A container within a StopPlace or Quay holding equipment items (shelters, waitin
 
 The root element of every NeTEx XML document, wrapping one or more frames with metadata (timestamp, participant, description).
 
+> **NeTEx XSD:** A set of NeTEx objects as assembled by a publication request or other service. Provides a general purpose wrapper for NeTEx data content.
+
 → [Example](../../Frames/Example_PublicationDelivery.xml)
 
 ---
@@ -218,6 +268,8 @@ The root element of every NeTEx XML document, wrapping one or more frames with m
 ## PurposeOfGrouping
 
 A classifier for the reason why NeTEx objects are grouped together (e.g., for presentation, regulation, or contract scope).
+
+> **NeTEx XSD:** Functional purpose for which GROUPs of elements are defined. The PURPOSE OF GROUPING may be restricted to one or more types of the given object.
 
 → [Full documentation](../../Objects/PurposeOfGrouping/Description_PurposeOfGrouping.md)
 
@@ -227,6 +279,8 @@ A classifier for the reason why NeTEx objects are grouped together (e.g., for pr
 
 A specific boarding or alighting position (platform, stand, bay) within a StopPlace where passengers physically meet vehicles.
 
+> **NeTEx XSD:** A place such as platform, stance, or quayside where passengers have access to PT vehicles, Taxi cars or other means of transportation. A QUAY may contain other sub QUAYs. A child QUAY must be physically contained within its parent QUAY.
+
 → [Full documentation](../../Objects/Quay/Description_Quay.md)
 
 ---
@@ -234,6 +288,8 @@ A specific boarding or alighting position (platform, stand, bay) within a StopPl
 ## ResponsibilitySet
 
 The set of roles and organisations responsible for managing data, operations, or contractual obligations within a defined scope.
+
+> **NeTEx XSD:** A set of responsibility roles assignments that can be associated with a DATA MANAGED OBJECT. A Child ENTITY has the same responsibilities as its parent.
 
 → [Full documentation](../../Objects/ResponsibilitySet/Description_ResponsibilitySet.md)
 
@@ -243,6 +299,8 @@ The set of roles and organisations responsible for managing data, operations, or
 
 The logical geographic path definition for a Line with a specific direction.
 
+> **NeTEx XSD:** An ordered list of located POINTs defining one single path through the Road (or rail) network. A ROUTE may pass through the same POINT more than once.
+
 → [Full documentation](../../Objects/Route/Description_Route.md)
 
 ---
@@ -251,6 +309,8 @@ The logical geographic path definition for a Line with a specific direction.
 
 Sanitary facilities (toilets, washrooms) available at a stop place, station, or onboard a vehicle.
 
+> **NeTEx XSD:** A SANITARY FACILITY, e.g. WC, Shower, baby change.
+
 → [Full documentation](../../Objects/SanitaryEquipment/Description_SanitaryEquipment.md)
 
 ---
@@ -258,6 +318,8 @@ Sanitary facilities (toilets, washrooms) available at a stop place, station, or 
 ## ScheduledStopPoint
 
 A logical stopping point in the timetable, used by JourneyPatterns and ServiceJourneys to define where vehicles stop.
+
+> **NeTEx XSD:** A POINT where passengers can board or alight from vehicles.
 
 → [Full documentation](../../Objects/ScheduledStopPoint/Description_ScheduledStopPoint.md)
 
@@ -275,6 +337,8 @@ An enumeration on DatedServiceJourney indicating the deviation type. Allowed val
 
 A planned trip in the timetable operating on a recurring schedule, defining the stop sequence via a JourneyPattern, passing times, operator, and days of operation.
 
+> **NeTEx XSD:** A passenger carrying VEHICLE JOURNEY for one specified DAY TYPE. The pattern of working is in principle defined by a SERVICE JOURNEY PATTERN.
+
 → [Full documentation](../../Objects/ServiceJourney/Description_ServiceJourney.md)
 
 ---
@@ -282,6 +346,8 @@ A planned trip in the timetable operating on a recurring schedule, defining the 
 ## ShelterEquipment
 
 Weather shelter facilities available at a stop place or quay, with properties such as seating, step-free access, and enclosure.
+
+> **NeTEx XSD:** Specialisation of WAITING EQUIPMENT for a SHELTER.
 
 → [Full documentation](../../Objects/ShelterEquipment/Description_ShelterEquipment.md)
 
@@ -291,6 +357,8 @@ Weather shelter facilities available at a stop place or quay, with properties su
 
 A named physical or virtual location where passengers can board or alight from public transport, containing one or more Quays.
 
+> **NeTEx XSD:** A named place where public transport may be accessed. May be a building complex (e.g. a station) or an on-street location.
+
 → [Full documentation](../../Objects/StopPlace/Description_StopPlace.md)
 
 ---
@@ -298,6 +366,8 @@ A named physical or virtual location where passengers can board or alight from p
 ## TariffZone
 
 A geographic fare zone used for ticketing and pricing, grouping stops and areas into zones that determine ticket prices.
+
+> **NeTEx XSD:** A ZONE used to define a zonal fare structure in a zone-counting or zone-matrix system.
 
 → [Full documentation](../../Objects/TariffZone/Description_TariffZone.md)
 
@@ -307,6 +377,8 @@ A geographic fare zone used for ticketing and pricing, grouping stops and areas 
 
 Ticket machines, validators, or other ticketing infrastructure available at a stop place or station.
 
+> **NeTEx XSD:** Specialisation of PASSENGER EQUIPMENT for ticketing.
+
 → [Full documentation](../../Objects/TicketingEquipment/Description_TicketingEquipment.md)
 
 ---
@@ -314,6 +386,8 @@ Ticket machines, validators, or other ticketing infrastructure available at a st
 ## TopographicPlace
 
 A named geographic area such as a city, municipality, county, or region - used to provide spatial context for StopPlaces.
+
+> **NeTEx XSD:** A town, city, village, suburb, quarter or other name settlement within a country. Provides a Gazetteer of Transport related place names.
 
 → [Full documentation](../../Objects/TopographicPlace/Description_TopographicPlace.md)
 
@@ -323,6 +397,8 @@ A named geographic area such as a city, municipality, county, or region - used t
 
 A rail-specific specialisation of Block that represents an operational grouping for a single train on a given operating day.
 
+> **NeTEx XSD:** The vehicle work required by a train-based JOURNEY or sequence of JOURNEYs, from the time it leaves a PARKING POINT after parking until its next return to park at a PARKING POINT.
+
 → [Full documentation](../../Objects/TrainBlock/Description_TrainBlock.md)
 
 ---
@@ -330,6 +406,8 @@ A rail-specific specialisation of Block that represents an operational grouping 
 ## Vehicle
 
 A specific physical vehicle in the fleet used to operate public transport services.
+
+> **NeTEx XSD:** A public transport vehicle used for carrying passengers.
 
 → [Full documentation](../../Objects/Vehicle/Description_Vehicle.md)
 
@@ -339,7 +417,19 @@ A specific physical vehicle in the fleet used to operate public transport servic
 
 A typified vehicle configuration (model or series) defining reusable characteristics such as capacity, dimensions, propulsion, and accessibility features.
 
+> **NeTEx XSD:** A classification of public transport vehicles according to the vehicle scheduling requirements in mode and capacity (e.g. standard bus, double-deck).
+
 → [Full documentation](../../Objects/VehicleType/Description_VehicleType.md)
+
+---
+
+## WaitingRoomEquipment
+
+Enclosed indoor waiting room facilities available at a stop place or station, with properties such as seating, step-free access, and heating.
+
+> **NeTEx XSD:** Specialisation of WAITING EQUIPMENT for WAITING ROOMs, classified by TYPE OF WAITING ROOM.
+
+→ [Full documentation](../../Objects/WaitingRoomEquipment/Description_WaitingRoomEquipment.md)
 
 ---
 
@@ -355,11 +445,3 @@ Clarifications:
 - When in doubt, prefer the precise NeTEx model terms (PublicationDelivery, TimetableFrame, DatedServiceJourney).
 
 → [DatedServiceJourney](../../Objects/DatedServiceJourney/Description_DatedServiceJourney.md)
-
----
-
-## WaitingRoomEquipment
-
-Enclosed indoor waiting room facilities available at a stop place or station, with properties such as seating, step-free access, and heating.
-
-→ [Full documentation](../../Objects/WaitingRoomEquipment/Description_WaitingRoomEquipment.md)

--- a/Guides/Glossary/Glossary.md
+++ b/Guides/Glossary/Glossary.md
@@ -1,7 +1,7 @@
 # Glossary
 
 Core terms used in this NeTEx profile, organised alphabetically.
-Each entry gives a short definition and a link to the full documentation.
+Each entry includes the profile definition, the official NeTEx XSD annotation, and (where applicable) the Transmodel (EN 12896) definition.
 
 <!-- entur-terms-ready: format maps to SKOS prefLabel + definition -->
 
@@ -12,6 +12,8 @@ Each entry gives a short definition and a link to the full documentation.
 Additional name variant for a NeTEx object - such as an official registration, translation, or abbreviation.
 
 > **NeTEx XSD:** Alternative Name.
+>
+> **Transmodel:** Alternative name for an ENTITY.
 
 → [Full documentation](../../Objects/AlternativeName/Description_AlternativeName.md)
 
@@ -22,6 +24,8 @@ Additional name variant for a NeTEx object - such as an official registration, t
 Supplementary textual description attached to any NeTEx object.
 
 > **NeTEx XSD:** Alternative Text.
+>
+> **Transmodel:** Alternative text for any textual attribute of an ENTITY.
 
 → [Full documentation](../../Objects/AlternativeText/Description_AlternativeText.md)
 
@@ -32,6 +36,8 @@ Supplementary textual description attached to any NeTEx object.
 A public transport organisation responsible for planning, organising, and managing public transport services within a specific geographical area.
 
 > **NeTEx XSD:** The ORGANISATION under which the responsibility of organising the transport service in a certain area is placed.
+>
+> **Transmodel:** The ORGANISATION on which the responsibility of organising the transport service in a certain area is placed.
 
 → [Full documentation](../../Objects/Authority/Description_Authority.md)
 
@@ -52,6 +58,8 @@ The namespace definition used for all NeTEx `@id` and `@ref` values within a dat
 A container frame that groups multiple typed frames (ServiceFrame, TimetableFrame, etc.) into a single coherent delivery.
 
 > **NeTEx XSD:** A container VERSION FRAME that groups a set of content VERSION FRAMEs to which the same VALIDITY CONDITIONs have been assigned.
+>
+> **Transmodel:** A set of VERSION FRAMEs to which the same VALIDITY CONDITIONs have been assigned.
 
 → [Full documentation](../../Frames/CompositeFrame/Description_CompositeFrame.md)
 
@@ -82,6 +90,8 @@ A specific operational instance of a ServiceJourney on a particular calendar day
 A classification of days on which a specific set of transport services operates (e.g., Weekdays, Saturdays, Public Holidays).
 
 > **NeTEx XSD:** A type of day characterized by one or more properties which affect public transport operation. For example: weekday in school holidays.
+>
+> **Transmodel:** A type of day characterised by one or more properties which affect public transport operation (for example: working day, sunday, weekday in school holidays, etc.).
 
 → [Full documentation](../../Objects/DayType/Description_DayType.md)
 
@@ -92,6 +102,8 @@ A classification of days on which a specific set of transport services operates 
 The binding between a DayType and a specific date or date range (OperatingPeriod), determining when that DayType is active - including exception handling via `isAvailable=false`.
 
 > **NeTEx XSD:** Associates a DAY TYPE with an OPERATING DAY within a specific Calendar. A specification of a particular DAY TYPE which will be valid during a TIME BAND on an OPERATING DAY.
+>
+> **Transmodel:** The assignment of operational characteristics, expressed by DAY TYPEs, to particular OPERATING DAYs within a SERVICE CALENDAR.
 
 → [Full documentation](../../Objects/DayTypeAssignment/Description_DayTypeAssignment.md)
 
@@ -102,6 +114,8 @@ The binding between a DayType and a specific date or date range (OperatingPeriod
 The text shown on the front or side of a public transport vehicle to indicate its destination, including via-points and variant labels.
 
 > **NeTEx XSD:** An advertised destination of a specific JOURNEY PATTERN, usually displayed on a head sign or at other on-board locations.
+>
+> **Transmodel:** An advertised destination of a specific JOURNEY PATTERN, usually displayed on a headsign or at other on-board locations.
 
 → [Full documentation](../../Objects/DestinationDisplay/Description_DestinationDisplay.md)
 
@@ -112,6 +126,8 @@ The text shown on the front or side of a public transport vehicle to indicate it
 A customer-facing agreement for the right to travel and consume fare products, defined within a SalesTransactionFrame (NeTEx Part 3 - Sales).
 
 > **NeTEx XSD:** A contract with a particular (but possibly anonymous) customer, ruling the consumption of transport services (and joint services). A FARE CONTRACT may be designed for a fixed SALES OFFER PACKAGE (e.g. ticket) or to allow successive purchases of SALES OFFER PACKAGEs.
+>
+> **Transmodel:** A contract with a particular (but possibly anonymous) customer, ruling the consumption of transport services (and joint services). A FARE CONTRACT may be designed for a fixed SALES OFFER PACKAGE (e.g., ticket) or to allow successive purchases of SALES OFFER PACKAGEs.
 
 → [Full documentation](../../Objects/FareContract/Description_FareContract.md)
 
@@ -132,6 +148,8 @@ A geographic zone used to determine ticket prices in public transport, grouping 
 The scheduling and operational characteristics of a flexible (demand-responsive) transport service, attached to a ServiceJourney.
 
 > **NeTEx XSD:** FLEXIBLE SERVICE PROPERTIES in frame.
+>
+> **Transmodel:** Flexibility characteristics of a SERVICE JOURNEY, e.g., cancelled unless ordered and/or timing may be adjusted at time of booking or even later for service optimisation purposes.
 
 → [Full documentation](../../Objects/FlexibleServiceProperties/Description_FlexibleServiceProperties.md)
 
@@ -152,6 +170,8 @@ A logical grouping of multiple Line objects for common management, branding, dis
 A planned transfer opportunity between two ServiceJourneys at a shared stop point, modelled as `ServiceJourneyInterchange` in XML.
 
 > **NeTEx XSD:** The scheduled possibility for transfer of passengers between two SERVICE JOURNEYs at the same or different STOP POINTs.
+>
+> **Transmodel:** The scheduled possibility for transfer of passengers between two SERVICE JOURNEYs at the same or different SCHEDULED STOP POINTs.
 
 → [Full documentation](../../Objects/Interchange/Description_Interchange.md)
 
@@ -162,6 +182,8 @@ A planned transfer opportunity between two ServiceJourneys at a shared stop poin
 The ordered sequence of ScheduledStopPoints that a transport service follows for a specific variant of a Route.
 
 > **NeTEx XSD:** An ordered list of SCHEDULED STOP POINTs and TIMING POINTs on a single ROUTE, describing the pattern of working for public transport vehicles. A JOURNEY PATTERN may pass through the same POINT more than once. The first point of a JOURNEY PATTERN is the origin. The last point is the destination.
+>
+> **Transmodel:** An ordered list of SCHEDULED STOP POINTs and TIMING POINTs on a single ROUTE, describing the pattern of working for public transport vehicles.
 
 → [Full documentation](../../Objects/JourneyPattern/Description_JourneyPattern.md)
 
@@ -192,6 +214,8 @@ The geographic representation of a ServiceLink, carrying GML geometry (typically
 Informational or regulatory text associated with public transport services, displayed to passengers.
 
 > **NeTEx XSD:** A note or footnote about any aspect of a service, e.g. an announcement, notice, etc. May have different DELIVERY VARIANTs for different media.
+>
+> **Transmodel:** A text for informational purposes on exceptions in a LINE, a JOURNEY PATTERN, etc. The information may be usable for passenger or driver information.
 
 → [Full documentation](../../Objects/Notice/Description_Notice.md)
 
@@ -202,6 +226,8 @@ Informational or regulatory text associated with public transport services, disp
 A specific calendar date on which transport services operate, referenced by DatedServiceJourney to anchor a journey to a concrete day.
 
 > **NeTEx XSD:** A day of public transport operation in a specific calendar. An OPERATING DAY may last more than 24 hours.
+>
+> **Transmodel:** A day of public transport operation of which the characteristics are defined within in a specific SERVICE CALENDAR. An OPERATING DAY may last more than 24 hours.
 
 → [Full documentation](../../Objects/OperatingDay/Description_OperatingDay.md)
 
@@ -232,6 +258,8 @@ An organisation that provides public transport services under contract with an A
 A parking facility associated with public transport - such as a park-and-ride lot, bike parking, or car park at a station.
 
 > **NeTEx XSD:** A named place where Parking may be accessed. May be a building complex (e.g. a station) or an on-street location.
+>
+> **Transmodel:** Designated locations for leaving vehicles such as cars, motorcycles and bicycles.
 
 → [Full documentation](../../Objects/Parking/Description_Parking.md)
 
@@ -242,6 +270,8 @@ A parking facility associated with public transport - such as a park-and-ride lo
 The bridge linking a logical ScheduledStopPoint to a physical Quay within a StopPlace, connecting timetable planning with physical infrastructure.
 
 > **NeTEx XSD:** The default allocation of a SCHEDULED STOP POINT to a specific STOP PLACE, and also possibly a QUAY and BOARDING POSITION.
+>
+> **Transmodel:** The default allocation of a SCHEDULED STOP POINT to a specific STOP PLACE, and also possibly a QUAY.
 
 → [Full documentation](../../Objects/PassengerStopAssignment/Description_PassengerStopAssignment.md)
 
@@ -280,6 +310,8 @@ A classifier for the reason why NeTEx objects are grouped together (e.g., for pr
 A specific boarding or alighting position (platform, stand, bay) within a StopPlace where passengers physically meet vehicles.
 
 > **NeTEx XSD:** A place such as platform, stance, or quayside where passengers have access to PT vehicles, Taxi cars or other means of transportation. A QUAY may contain other sub QUAYs. A child QUAY must be physically contained within its parent QUAY.
+>
+> **Transmodel:** A place such as platform, stance, or quay side where passengers have access to PT vehicles, Taxis, cars or other means of transportation.
 
 → [Full documentation](../../Objects/Quay/Description_Quay.md)
 
@@ -290,6 +322,8 @@ A specific boarding or alighting position (platform, stand, bay) within a StopPl
 The set of roles and organisations responsible for managing data, operations, or contractual obligations within a defined scope.
 
 > **NeTEx XSD:** A set of responsibility roles assignments that can be associated with a DATA MANAGED OBJECT. A Child ENTITY has the same responsibilities as its parent.
+>
+> **Transmodel:** A list of possible responsibilities over one or more ENTITies IN VERSION, resulting from the process of the assignment of RESPONSIBILITY ROLEs (such as data origination, ownership, etc.) on specific data (instances) to ORGANISATIONs or ORGANISATION PARTs.
 
 → [Full documentation](../../Objects/ResponsibilitySet/Description_ResponsibilitySet.md)
 
@@ -310,6 +344,8 @@ The logical geographic path definition for a Line with a specific direction.
 Sanitary facilities (toilets, washrooms) available at a stop place, station, or onboard a vehicle.
 
 > **NeTEx XSD:** A SANITARY FACILITY, e.g. WC, Shower, baby change.
+>
+> **Transmodel:** Specialisation of PASSENGER EQUIPMENT describing sanitary facilities (WC, shower, etc.).
 
 → [Full documentation](../../Objects/SanitaryEquipment/Description_SanitaryEquipment.md)
 
@@ -348,6 +384,8 @@ A planned trip in the timetable operating on a recurring schedule, defining the 
 Weather shelter facilities available at a stop place or quay, with properties such as seating, step-free access, and enclosure.
 
 > **NeTEx XSD:** Specialisation of WAITING EQUIPMENT for a SHELTER.
+>
+> **Transmodel:** Specialisation of WAITING EQUIPMENT describing a shelter.
 
 → [Full documentation](../../Objects/ShelterEquipment/Description_ShelterEquipment.md)
 
@@ -358,6 +396,8 @@ Weather shelter facilities available at a stop place or quay, with properties su
 A named physical or virtual location where passengers can board or alight from public transport, containing one or more Quays.
 
 > **NeTEx XSD:** A named place where public transport may be accessed. May be a building complex (e.g. a station) or an on-street location.
+>
+> **Transmodel:** A place comprising one or more locations where vehicles may stop and where passengers may board or leave vehicles or prepare their trip. A STOP PLACE will usually have one or more well-known names.
 
 → [Full documentation](../../Objects/StopPlace/Description_StopPlace.md)
 
@@ -378,6 +418,8 @@ A geographic fare zone used for ticketing and pricing, grouping stops and areas 
 Ticket machines, validators, or other ticketing infrastructure available at a stop place or station.
 
 > **NeTEx XSD:** Specialisation of PASSENGER EQUIPMENT for ticketing.
+>
+> **Transmodel:** Specialization of PASSENGER EQUIPMENT for ticketing.
 
 → [Full documentation](../../Objects/TicketingEquipment/Description_TicketingEquipment.md)
 
@@ -388,6 +430,8 @@ Ticket machines, validators, or other ticketing infrastructure available at a st
 A named geographic area such as a city, municipality, county, or region - used to provide spatial context for StopPlaces.
 
 > **NeTEx XSD:** A town, city, village, suburb, quarter or other name settlement within a country. Provides a Gazetteer of Transport related place names.
+>
+> **Transmodel:** A type of PLACE providing the topographical context when searching for or presenting travel information, for example as the origin or destination of a trip.
 
 → [Full documentation](../../Objects/TopographicPlace/Description_TopographicPlace.md)
 
@@ -418,6 +462,8 @@ A specific physical vehicle in the fleet used to operate public transport servic
 A typified vehicle configuration (model or series) defining reusable characteristics such as capacity, dimensions, propulsion, and accessibility features.
 
 > **NeTEx XSD:** A classification of public transport vehicles according to the vehicle scheduling requirements in mode and capacity (e.g. standard bus, double-deck).
+>
+> **Transmodel:** A classification of public transport vehicles according to the vehicle scheduling requirements in mode and capacity (e.g., standard bus, double-decker, etc.).
 
 → [Full documentation](../../Objects/VehicleType/Description_VehicleType.md)
 
@@ -428,6 +474,8 @@ A typified vehicle configuration (model or series) defining reusable characteris
 Enclosed indoor waiting room facilities available at a stop place or station, with properties such as seating, step-free access, and heating.
 
 > **NeTEx XSD:** Specialisation of WAITING EQUIPMENT for WAITING ROOMs, classified by TYPE OF WAITING ROOM.
+>
+> **Transmodel:** Specialisation of WAITING EQUIPMENT describing waiting rooms (number of seats, type, FACILITIEs, etc.).
 
 → [Full documentation](../../Objects/WaitingRoomEquipment/Description_WaitingRoomEquipment.md)
 

--- a/Guides/Glossary/Glossary.md
+++ b/Guides/Glossary/Glossary.md
@@ -69,7 +69,7 @@ A container frame that groups multiple typed frames (ServiceFrame, TimetableFram
 
 A legal or commercial agreement governing responsibilities between an Authority (contractee) and an Operator (contractor) for providing public transport services.
 
-> **NeTEx XSD:** A CONTRACT between ORGANISATIONs to supply services or goods.
+> **NeTEx XSD / Transmodel:** A CONTRACT between ORGANISATIONs to supply services or goods.
 
 → [Full documentation](../../Objects/Contract/Description_Contract.md)
 
@@ -77,9 +77,11 @@ A legal or commercial agreement governing responsibilities between an Authority 
 
 ## DatedServiceJourney
 
-A specific operational instance of a ServiceJourney on a particular calendar day, including day-specific modifications such as cancellations, replacements, or reinforcements.
+A specific operational instance of a ServiceJourney on a particular calendar day, including day-specific modifications such as cancellations, replacements, or reinforcements. DatedServiceJourney is a NeTEx specialisation of the Transmodel concept DATED VEHICLE JOURNEY.
 
 > **NeTEx XSD:** A particular SERVICE JOURNEY of a vehicle on a particular OPERATING DAY including all modifications possibly decided by the control staff.
+>
+> **Transmodel:** A particular journey of a vehicle on a particular OPERATING DAY including all modifications possibly decided by the control staff. *(Transmodel: DATED VEHICLE JOURNEY)*
 
 → [Full documentation](../../Objects/DatedServiceJourney/Description_DatedServiceJourney.md)
 
@@ -113,9 +115,7 @@ The binding between a DayType and a specific date or date range (OperatingPeriod
 
 The text shown on the front or side of a public transport vehicle to indicate its destination, including via-points and variant labels.
 
-> **NeTEx XSD:** An advertised destination of a specific JOURNEY PATTERN, usually displayed on a head sign or at other on-board locations.
->
-> **Transmodel:** An advertised destination of a specific JOURNEY PATTERN, usually displayed on a headsign or at other on-board locations.
+> **NeTEx XSD / Transmodel:** An advertised destination of a specific JOURNEY PATTERN, usually displayed on a headsign or at other on-board locations.
 
 → [Full documentation](../../Objects/DestinationDisplay/Description_DestinationDisplay.md)
 
@@ -125,9 +125,7 @@ The text shown on the front or side of a public transport vehicle to indicate it
 
 A customer-facing agreement for the right to travel and consume fare products, defined within a SalesTransactionFrame (NeTEx Part 3 - Sales).
 
-> **NeTEx XSD:** A contract with a particular (but possibly anonymous) customer, ruling the consumption of transport services (and joint services). A FARE CONTRACT may be designed for a fixed SALES OFFER PACKAGE (e.g. ticket) or to allow successive purchases of SALES OFFER PACKAGEs.
->
-> **Transmodel:** A contract with a particular (but possibly anonymous) customer, ruling the consumption of transport services (and joint services). A FARE CONTRACT may be designed for a fixed SALES OFFER PACKAGE (e.g., ticket) or to allow successive purchases of SALES OFFER PACKAGEs.
+> **NeTEx XSD / Transmodel:** A contract with a particular (but possibly anonymous) customer, ruling the consumption of transport services (and joint services). A FARE CONTRACT may be designed for a fixed SALES OFFER PACKAGE (e.g. ticket) or to allow successive purchases of SALES OFFER PACKAGEs.
 
 → [Full documentation](../../Objects/FareContract/Description_FareContract.md)
 
@@ -137,7 +135,7 @@ A customer-facing agreement for the right to travel and consume fare products, d
 
 A geographic zone used to determine ticket prices in public transport, grouping stop points for fare calculation.
 
-> **NeTEx XSD:** A specialization of TARIFF ZONE to include FARE SECTIONs.
+> **NeTEx XSD / Transmodel:** A specialization of TARIFF ZONE to include FARE SECTIONs.
 
 → [Full documentation](../../Objects/FareZone/Description_FareZone.md)
 
@@ -159,7 +157,7 @@ The scheduling and operational characteristics of a flexible (demand-responsive)
 
 A logical grouping of multiple Line objects for common management, branding, distribution, or filtering.
 
-> **NeTEx XSD:** A grouping of LINEs which will be commonly referenced for a specific purpose.
+> **NeTEx XSD / Transmodel:** A grouping of LINEs which will be commonly referenced for a specific purpose.
 
 → [Full documentation](../../Objects/GroupOfLines/Description_GroupOfLines.md)
 
@@ -193,7 +191,7 @@ The ordered sequence of ScheduledStopPoints that a transport service follows for
 
 A public transport service line, representing a marketed route with a name, transport mode, and operator.
 
-> **NeTEx XSD:** A group of ROUTEs which is generally known to the public by a similar name or number.
+> **NeTEx XSD / Transmodel:** A group of ROUTEs which is generally known to the public by a similar name or number.
 
 → [Full documentation](../../Objects/Line/Description_Line.md)
 
@@ -237,7 +235,7 @@ A specific calendar date on which transport services operate, referenced by Date
 
 A continuous date range (FromDate-ToDate) during which a set of transport services may operate, used by DayTypeAssignment.
 
-> **NeTEx XSD:** A continuous interval of time between two OPERATING DAYs which will be used to define validities.
+> **NeTEx XSD / Transmodel:** A continuous interval of time between two OPERATING DAYs which will be used to define validities.
 
 → [Full documentation](../../Objects/OperatingPeriod/Description_OperatingPeriod.md)
 
@@ -247,7 +245,7 @@ A continuous date range (FromDate-ToDate) during which a set of transport servic
 
 An organisation that provides public transport services under contract with an Authority.
 
-> **NeTEx XSD:** A company providing public transport services.
+> **NeTEx XSD / Transmodel:** A company providing public transport services.
 
 → [Full documentation](../../Objects/Operator/Description_Operator.md)
 
@@ -299,7 +297,7 @@ The root element of every NeTEx XML document, wrapping one or more frames with m
 
 A classifier for the reason why NeTEx objects are grouped together (e.g., for presentation, regulation, or contract scope).
 
-> **NeTEx XSD:** Functional purpose for which GROUPs of elements are defined. The PURPOSE OF GROUPING may be restricted to one or more types of the given object.
+> **NeTEx XSD / Transmodel:** Functional purpose for which GROUPs of elements are defined. The PURPOSE OF GROUPING may be restricted to one or more types of the given object.
 
 → [Full documentation](../../Objects/PurposeOfGrouping/Description_PurposeOfGrouping.md)
 
@@ -333,7 +331,7 @@ The set of roles and organisations responsible for managing data, operations, or
 
 The logical geographic path definition for a Line with a specific direction.
 
-> **NeTEx XSD:** An ordered list of located POINTs defining one single path through the Road (or rail) network. A ROUTE may pass through the same POINT more than once.
+> **NeTEx XSD / Transmodel:** An ordered list of located POINTs defining one single path through the road (or rail) network. A ROUTE may pass through the same POINT more than once.
 
 → [Full documentation](../../Objects/Route/Description_Route.md)
 
@@ -355,7 +353,7 @@ Sanitary facilities (toilets, washrooms) available at a stop place, station, or 
 
 A logical stopping point in the timetable, used by JourneyPatterns and ServiceJourneys to define where vehicles stop.
 
-> **NeTEx XSD:** A POINT where passengers can board or alight from vehicles.
+> **NeTEx XSD / Transmodel:** A POINT where passengers can board or alight from vehicles.
 
 → [Full documentation](../../Objects/ScheduledStopPoint/Description_ScheduledStopPoint.md)
 
@@ -373,7 +371,7 @@ An enumeration on DatedServiceJourney indicating the deviation type. Allowed val
 
 A planned trip in the timetable operating on a recurring schedule, defining the stop sequence via a JourneyPattern, passing times, operator, and days of operation.
 
-> **NeTEx XSD:** A passenger carrying VEHICLE JOURNEY for one specified DAY TYPE. The pattern of working is in principle defined by a SERVICE JOURNEY PATTERN.
+> **NeTEx XSD / Transmodel:** A passenger carrying VEHICLE JOURNEY for one specified DAY TYPE. The pattern of working is in principle defined by a SERVICE JOURNEY PATTERN.
 
 → [Full documentation](../../Objects/ServiceJourney/Description_ServiceJourney.md)
 
@@ -407,7 +405,7 @@ A named physical or virtual location where passengers can board or alight from p
 
 A geographic fare zone used for ticketing and pricing, grouping stops and areas into zones that determine ticket prices.
 
-> **NeTEx XSD:** A ZONE used to define a zonal fare structure in a zone-counting or zone-matrix system.
+> **NeTEx XSD / Transmodel:** A ZONE used to define a zonal fare structure in a zone-counting or zone-matrix system.
 
 → [Full documentation](../../Objects/TariffZone/Description_TariffZone.md)
 
@@ -417,9 +415,7 @@ A geographic fare zone used for ticketing and pricing, grouping stops and areas 
 
 Ticket machines, validators, or other ticketing infrastructure available at a stop place or station.
 
-> **NeTEx XSD:** Specialisation of PASSENGER EQUIPMENT for ticketing.
->
-> **Transmodel:** Specialization of PASSENGER EQUIPMENT for ticketing.
+> **NeTEx XSD / Transmodel:** Specialisation of PASSENGER EQUIPMENT for ticketing.
 
 → [Full documentation](../../Objects/TicketingEquipment/Description_TicketingEquipment.md)
 
@@ -442,6 +438,8 @@ A named geographic area such as a city, municipality, county, or region - used t
 A rail-specific specialisation of Block that represents an operational grouping for a single train on a given operating day.
 
 > **NeTEx XSD:** The vehicle work required by a train-based JOURNEY or sequence of JOURNEYs, from the time it leaves a PARKING POINT after parking until its next return to park at a PARKING POINT.
+>
+> **Transmodel:** The work required to be done by a vehicle from the time it leaves a PARKING POINT after parking until its next return to park at a PARKING POINT. *(Transmodel: BLOCK)*
 
 → [Full documentation](../../Objects/TrainBlock/Description_TrainBlock.md)
 
@@ -451,7 +449,7 @@ A rail-specific specialisation of Block that represents an operational grouping 
 
 A specific physical vehicle in the fleet used to operate public transport services.
 
-> **NeTEx XSD:** A public transport vehicle used for carrying passengers.
+> **NeTEx XSD / Transmodel:** A public transport vehicle used for carrying passengers.
 
 → [Full documentation](../../Objects/Vehicle/Description_Vehicle.md)
 


### PR DESCRIPTION
## Summary

Expands the Glossary from 1 term (View) to **44 terms** covering all documented NeTEx objects, with a three-layer definition structure:

1. **Profile definition** - plain-language description for readers of this profile
2. **NeTEx XSD** - official annotation from the CEN XSD schema
3. **Transmodel (EN 12896)** - definition from the Transmodel v6.2 conceptual model

### Key design decisions

- Identical NeTEx/Transmodel defs merged under `NeTEx XSD / Transmodel:` label (15 entries)
- DatedServiceJourney noted as specialisation of DATED VEHICLE JOURNEY
- TrainBlock mapped to Transmodel BLOCK
- SKOS-ready format for future entur-terms import