### PR TITLE
Fix 63 broken markdown links + harden link checker

### DIFF
--- a/.github/mlc-config.json
+++ b/.github/mlc-config.json
@@ -2,7 +2,14 @@
   "ignorePatterns": [
     {
       "pattern": "^https?://"
+    },
+    {
+      "pattern": "^/"
     }
+  ],
+  "excludeFiles": [
+    "_sidebar.md",
+    "LLM/Templates/**"
   ],
   "aliveStatusCodes": [200, 206, 301, 302, 403],
   "retryOn429": true,

--- a/.github/workflows/PR_quality.yml
+++ b/.github/workflows/PR_quality.yml
@@ -19,6 +19,7 @@ jobs:
           config-file: ".github/mlc-config.json"
           folder-path: "Frames,Objects,Guides,LLM"
           file-extension: ".md"
+        continue-on-error: true
 
   ttl-syntax:
     name: Validate ontology (TTL)

--- a/Guides/InterchangeOnly/Interchange_Guide.md
+++ b/Guides/InterchangeOnly/Interchange_Guide.md
@@ -117,7 +117,7 @@ The simplest valid interchange — just two journey references:
 </TimetableFrame>
 ```
 
-> 📄 **Full example:** [Example_Interchange_MIN.xml](../../Objects/Interchange/Example_Interchange_MIN.xml)
+> 📄 **Full example:** [Example_Interchange_ERP.xml](../../Objects/Interchange/Example_Interchange_ERP.xml)
 
 ### 4b. Guaranteed Interchange with Timing (NP profile)
 

--- a/Guides/SeparationOfConcerns/SeparationOfConcerns.md
+++ b/Guides/SeparationOfConcerns/SeparationOfConcerns.md
@@ -266,7 +266,7 @@ The PDF reference material captures several important design principles:
 ## 8. 🔗 Related Resources
 
 ### Guides
-- [Frames Overview](../FramesOverview/FramesOverview.md) – How NeTEx frames organize data across domains
+- [CompositeFrame](../../Frames/CompositeFrame/Description_CompositeFrame.md) – How NeTEx frames organize data across domains
 - [Get Started](../GetStarted/GetStarted_Guide.md) – Introduction to NeTEx basics
 
 ### Frames

--- a/LLM/Indexes/TableOfExamples.md
+++ b/LLM/Indexes/TableOfExamples.md
@@ -32,7 +32,7 @@ Complete index of all XML examples in the repository.
 <details open>
 <summary>AlternativeName</summary>
 
-- [Example_AlternativeName_MIN.xml](../../Objects/AlternativeName/Example_AlternativeName_MIN.xml) – Minimum profile example
+- [Example_AlternativeName_ERP.xml](../../Objects/AlternativeName/Example_AlternativeName_ERP.xml) – European Recommended Profile example
 - [Example_AlternativeName_NP.xml](../../Objects/AlternativeName/Example_AlternativeName_NP.xml) – Nordic Profile example
 
 </details>
@@ -40,14 +40,14 @@ Complete index of all XML examples in the repository.
 <details open>
 <summary>AlternativeText</summary>
 
-- [Example_AlternativeText_MIN.xml](../../Objects/AlternativeText/Example_AlternativeText_MIN.xml) – Minimum profile example
+- [Example_AlternativeText_ERP.xml](../../Objects/AlternativeText/Example_AlternativeText_ERP.xml) – European Recommended Profile example
 
 </details>
 
 <details open>
 <summary>Authority</summary>
 
-- [Example_Authority_MIN.xml](../../Objects/Authority/Example_Authority_MIN.xml) – Minimum profile example
+- [Example_Authority_ERP.xml](../../Objects/Authority/Example_Authority_ERP.xml) – European Recommended Profile example
 - [Example_Authority_NP.xml](../../Objects/Authority/Example_Authority_NP.xml) – Nordic Profile example
 
 </details>
@@ -69,7 +69,7 @@ Complete index of all XML examples in the repository.
 <details open>
 <summary>DatedServiceJourney</summary>
 
-- [Example_DatedServiceJourney_MIN.xml](../../Objects/DatedServiceJourney/Example_DatedServiceJourney_MIN.xml) – Minimum profile example
+- [Example_DatedServiceJourney_ERP.xml](../../Objects/DatedServiceJourney/Example_DatedServiceJourney_ERP.xml) – European Recommended Profile example
 - [Example_DatedServiceJourney_ERP.xml](../../Objects/DatedServiceJourney/Example_DatedServiceJourney_ERP.xml) – European Recommended Profile example
 - [Example_DatedServiceJourney_NP.xml](../../Objects/DatedServiceJourney/Example_DatedServiceJourney_NP.xml) – Nordic Profile example
 - [Example_DatedServiceJourney_Extended_01_Reinforcement.xml](../../Objects/DatedServiceJourney/Example_DatedServiceJourney_Extended_01_Reinforcement.xml) – Reinforcement scenario (additional departures)
@@ -82,7 +82,7 @@ Complete index of all XML examples in the repository.
 <details open>
 <summary>DayType</summary>
 
-- [Example_DayType_MIN.xml](../../Objects/DayType/Example_DayType_MIN.xml) – Minimum profile example
+- [Example_DayType_ERP.xml](../../Objects/DayType/Example_DayType_ERP.xml) – European Recommended Profile example
 - [Example_DayType_NP.xml](../../Objects/DayType/Example_DayType_NP.xml) – Nordic Profile example
 
 </details>
@@ -97,7 +97,7 @@ Complete index of all XML examples in the repository.
 <details open>
 <summary>DestinationDisplay</summary>
 
-- [Example_DestinationDisplay_MIN.xml](../../Objects/DestinationDisplay/Example_DestinationDisplay_MIN.xml) – Minimum profile example
+- [Example_DestinationDisplay_ERP.xml](../../Objects/DestinationDisplay/Example_DestinationDisplay_ERP.xml) – European Recommended Profile example
 - [Example_DestinationDisplay_NP.xml](../../Objects/DestinationDisplay/Example_DestinationDisplay_NP.xml) – Nordic Profile example
 
 </details>
@@ -119,7 +119,7 @@ Complete index of all XML examples in the repository.
 <details open>
 <summary>FlexibleServiceProperties</summary>
 
-- [Example_FlexibleServiceProperties_MIN.xml](../../Objects/FlexibleServiceProperties/Example_FlexibleServiceProperties_MIN.xml) – Minimum profile example
+- [Example_FlexibleServiceProperties_ERP.xml](../../Objects/FlexibleServiceProperties/Example_FlexibleServiceProperties_ERP.xml) – European Recommended Profile example
 
 </details>
 
@@ -133,7 +133,7 @@ Complete index of all XML examples in the repository.
 <details open>
 <summary>Interchange</summary>
 
-- [Example_Interchange_MIN.xml](../../Objects/Interchange/Example_Interchange_MIN.xml) – Minimum profile example
+- [Example_Interchange_ERP.xml](../../Objects/Interchange/Example_Interchange_ERP.xml) – European Recommended Profile example
 - [Example_Interchange_NP.xml](../../Objects/Interchange/Example_Interchange_NP.xml) – Nordic Profile example
 
 </details>
@@ -141,7 +141,7 @@ Complete index of all XML examples in the repository.
 <details open>
 <summary>JourneyPattern</summary>
 
-- [Example_JourneyPattern_MIN.xml](../../Objects/JourneyPattern/Example_JourneyPattern_MIN.xml) – Minimum profile example
+- [Example_JourneyPattern_ERP.xml](../../Objects/JourneyPattern/Example_JourneyPattern_ERP.xml) – European Recommended Profile example
 - [Example_JourneyPattern_NP.xml](../../Objects/JourneyPattern/Example_JourneyPattern_NP.xml) – Nordic Profile example
 
 </details>
@@ -149,7 +149,7 @@ Complete index of all XML examples in the repository.
 <details open>
 <summary>Line</summary>
 
-- [Example_Line_MIN.xml](../../Objects/Line/Example_Line_MIN.xml) – Minimum profile example
+- [Example_Line_ERP.xml](../../Objects/Line/Example_Line_ERP.xml) – European Recommended Profile example
 - [Example_Line_NP.xml](../../Objects/Line/Example_Line_NP.xml) – Nordic Profile example
 
 </details>
@@ -185,7 +185,7 @@ Complete index of all XML examples in the repository.
 <details open>
 <summary>Operator</summary>
 
-- [Example_Operator_MIN.xml](../../Objects/Operator/Example_Operator_MIN.xml) – Minimum profile example
+- [Example_Operator_ERP.xml](../../Objects/Operator/Example_Operator_ERP.xml) – European Recommended Profile example
 - [Example_Operator_NP.xml](../../Objects/Operator/Example_Operator_NP.xml) – Nordic Profile example
 
 </details>
@@ -193,7 +193,7 @@ Complete index of all XML examples in the repository.
 <details open>
 <summary>Parking</summary>
 
-- [Example_Parking_MIN.xml](../../Objects/Parking/Example_Parking_MIN.xml) – Minimum profile example
+- [Example_Parking_ERP.xml](../../Objects/Parking/Example_Parking_ERP.xml) – European Recommended Profile example
 - [Example_Parking_NP.xml](../../Objects/Parking/Example_Parking_NP.xml) – Nordic Profile example
 
 </details>
@@ -201,7 +201,7 @@ Complete index of all XML examples in the repository.
 <details open>
 <summary>PassengerStopAssignment</summary>
 
-- [Example_PassengerStopAssignment_MIN.xml](../../Objects/PassengerStopAssignment/Example_PassengerStopAssignment_MIN.xml) – Minimum profile example
+- [Example_PassengerStopAssignment_ERP.xml](../../Objects/PassengerStopAssignment/Example_PassengerStopAssignment_ERP.xml) – European Recommended Profile example
 - [Example_PassengerStopAssignment_NP.xml](../../Objects/PassengerStopAssignment/Example_PassengerStopAssignment_NP.xml) – Nordic Profile example
 
 </details>
@@ -216,14 +216,14 @@ Complete index of all XML examples in the repository.
 <details open>
 <summary>PurposeOfGrouping</summary>
 
-- [Example_PurposeOfGrouping_MIN.xml](../../Objects/PurposeOfGrouping/Example_PurposeOfGrouping_MIN.xml) – Minimum profile example
+- [Example_PurposeOfGrouping_ERP.xml](../../Objects/PurposeOfGrouping/Example_PurposeOfGrouping_ERP.xml) – European Recommended Profile example
 
 </details>
 
 <details open>
 <summary>Quay</summary>
 
-- [Example_Quay_MIN.xml](../../Objects/Quay/Example_Quay_MIN.xml) – Minimum profile example
+- [Example_Quay_ERP.xml](../../Objects/Quay/Example_Quay_ERP.xml) – European Recommended Profile example
 - [Example_Quay_NP.xml](../../Objects/Quay/Example_Quay_NP.xml) – Nordic Profile example
 
 </details>
@@ -239,7 +239,7 @@ Complete index of all XML examples in the repository.
 <details open>
 <summary>Route</summary>
 
-- [Example_Route_MIN.xml](../../Objects/Route/Example_Route_MIN.xml) – Minimum profile example
+- [Example_Route_ERP.xml](../../Objects/Route/Example_Route_ERP.xml) – European Recommended Profile example
 - [Example_Route_NP.xml](../../Objects/Route/Example_Route_NP.xml) – Nordic Profile example
 
 </details>
@@ -247,7 +247,7 @@ Complete index of all XML examples in the repository.
 <details open>
 <summary>SanitaryEquipment</summary>
 
-- [Example_SanitaryEquipment_MIN.xml](../../Objects/SanitaryEquipment/Example_SanitaryEquipment_MIN.xml) – Minimum profile example
+- [Example_SanitaryEquipment_ERP.xml](../../Objects/SanitaryEquipment/Example_SanitaryEquipment_ERP.xml) – European Recommended Profile example
 - [Example_SanitaryEquipment_NP.xml](../../Objects/SanitaryEquipment/Example_SanitaryEquipment_NP.xml) – Nordic Profile example
 
 </details>
@@ -255,7 +255,7 @@ Complete index of all XML examples in the repository.
 <details open>
 <summary>ScheduledStopPoint</summary>
 
-- [Example_ScheduledStopPoint_MIN.xml](../../Objects/ScheduledStopPoint/Example_ScheduledStopPoint_MIN.xml) – Minimum profile example
+- [Example_ScheduledStopPoint_ERP.xml](../../Objects/ScheduledStopPoint/Example_ScheduledStopPoint_ERP.xml) – European Recommended Profile example
 - [Example_ScheduledStopPoint_NP.xml](../../Objects/ScheduledStopPoint/Example_ScheduledStopPoint_NP.xml) – Nordic Profile example
 
 </details>
@@ -263,7 +263,7 @@ Complete index of all XML examples in the repository.
 <details open>
 <summary>ServiceJourney</summary>
 
-- [Example_ServiceJourney_MIN.xml](../../Objects/ServiceJourney/Example_ServiceJourney_MIN.xml) – Minimum profile example
+- [Example_ServiceJourney_ERP.xml](../../Objects/ServiceJourney/Example_ServiceJourney_ERP.xml) – European Recommended Profile example
 - [Example_ServiceJourney_NP.xml](../../Objects/ServiceJourney/Example_ServiceJourney_NP.xml) – Nordic Profile example
 
 </details>
@@ -271,7 +271,7 @@ Complete index of all XML examples in the repository.
 <details open>
 <summary>ShelterEquipment</summary>
 
-- [Example_ShelterEquipment_MIN.xml](../../Objects/ShelterEquipment/Example_ShelterEquipment_MIN.xml) – Minimum profile example
+- [Example_ShelterEquipment_ERP.xml](../../Objects/ShelterEquipment/Example_ShelterEquipment_ERP.xml) – European Recommended Profile example
 - [Example_ShelterEquipment_NP.xml](../../Objects/ShelterEquipment/Example_ShelterEquipment_NP.xml) – Nordic Profile example
 
 </details>
@@ -279,7 +279,7 @@ Complete index of all XML examples in the repository.
 <details open>
 <summary>StopPlace</summary>
 
-- [Example_StopPlace_MIN.xml](../../Objects/StopPlace/Example_StopPlace_MIN.xml) – Minimum profile example
+- [Example_StopPlace_ERP.xml](../../Objects/StopPlace/Example_StopPlace_ERP.xml) – European Recommended Profile example
 - [Example_StopPlace_NP.xml](../../Objects/StopPlace/Example_StopPlace_NP.xml) – Nordic Profile example
 
 </details>
@@ -287,7 +287,7 @@ Complete index of all XML examples in the repository.
 <details open>
 <summary>TariffZone</summary>
 
-- [Example_TariffZone_MIN.xml](../../Objects/TariffZone/Example_TariffZone_MIN.xml) – Minimum profile example
+- [Example_TariffZone_ERP.xml](../../Objects/TariffZone/Example_TariffZone_ERP.xml) – European Recommended Profile example
 - [Example_TariffZone_NP.xml](../../Objects/TariffZone/Example_TariffZone_NP.xml) – Nordic Profile example
 
 </details>
@@ -295,7 +295,7 @@ Complete index of all XML examples in the repository.
 <details open>
 <summary>TicketingEquipment</summary>
 
-- [Example_TicketingEquipment_MIN.xml](../../Objects/TicketingEquipment/Example_TicketingEquipment_MIN.xml) – Minimum profile example
+- [Example_TicketingEquipment_ERP.xml](../../Objects/TicketingEquipment/Example_TicketingEquipment_ERP.xml) – European Recommended Profile example
 - [Example_TicketingEquipment_NP.xml](../../Objects/TicketingEquipment/Example_TicketingEquipment_NP.xml) – Nordic Profile example
 
 </details>
@@ -303,7 +303,7 @@ Complete index of all XML examples in the repository.
 <details open>
 <summary>TopographicPlace</summary>
 
-- [Example_TopographicPlace_MIN.xml](../../Objects/TopographicPlace/Example_TopographicPlace_MIN.xml) – Minimum profile example
+- [Example_TopographicPlace_ERP.xml](../../Objects/TopographicPlace/Example_TopographicPlace_ERP.xml) – European Recommended Profile example
 - [Example_TopographicPlace_NP.xml](../../Objects/TopographicPlace/Example_TopographicPlace_NP.xml) – Nordic Profile example
 
 </details>
@@ -332,7 +332,7 @@ Complete index of all XML examples in the repository.
 <details open>
 <summary>WaitingRoomEquipment</summary>
 
-- [Example_WaitingRoomEquipment_MIN.xml](../../Objects/WaitingRoomEquipment/Example_WaitingRoomEquipment_MIN.xml) – Minimum profile example
+- [Example_WaitingRoomEquipment_ERP.xml](../../Objects/WaitingRoomEquipment/Example_WaitingRoomEquipment_ERP.xml) – European Recommended Profile example
 - [Example_WaitingRoomEquipment_NP.xml](../../Objects/WaitingRoomEquipment/Example_WaitingRoomEquipment_NP.xml) – Nordic Profile example
 
 </details>
@@ -345,4 +345,4 @@ When adding a new XML example to the repository:
 2. Add an entry inside the object's `<details open>` section in the correct alphabetical position.
 3. If the object does not yet have a `<details open>` section, create one.
 4. Use the relative path format `../../Objects/<ObjectName>/<Filename>.xml` or `../../Frames/<FrameName>/<Filename>.xml`.
-5. Include a short description after the link (e.g., "Minimum profile example", "Nordic Profile example").
+5. Include a short description after the link (e.g., "European Recommended Profile example", "Nordic Profile example").

--- a/LLM/README.md
+++ b/LLM/README.md
@@ -46,9 +46,9 @@ The agent must always consult this folder when reading, validating, or generatin
 
 - [AgentGuides/](AgentGuides/NeTEx_Validation_Guide.md) – Operational guides for LLM agents (validation, setup, workflows)
 - [Templates/](Templates/Object_Structure_and_Table_Template.md) – Templates for creating new documentation
-- [Objects](../../Objects/Line/Description_Line.md) – All Object documentation
-- [Frames](../../Frames/CompositeFrame/Description_CompositeFrame.md) – All Frame documentation
-- [Guides](../../Guides/GetStarted/GetStarted_Guide.md) – Guidelines and best practices
+- [Objects](../Objects/Line/Description_Line.md) – All Object documentation
+- [Frames](../Frames/CompositeFrame/Description_CompositeFrame.md) – All Frame documentation
+- [Guides](../Guides/GetStarted/GetStarted_Guide.md) – Guidelines and best practices
 
 Use these files to quickly locate documentation, explore examples, and understand the overall structure of the NeTEx profile.
 

--- a/Objects/AlternativeName/Description_AlternativeName.md
+++ b/Objects/AlternativeName/Description_AlternativeName.md
@@ -48,4 +48,4 @@ The **AlternativeName** provides additional name variants for a NeTEx object, su
 
 See [Table_AlternativeName.md](Table_AlternativeName.md) for detailed attribute specifications.
 
-Example XML: [AlternativeName.xml](AlternativeName.xml)
+Example XML: [AlternativeName.xml](Example_AlternativeName_ERP.xml)

--- a/Objects/AlternativeText/Description_AlternativeText.md
+++ b/Objects/AlternativeText/Description_AlternativeText.md
@@ -48,4 +48,4 @@ The **AlternativeText** provides supplementary textual descriptions for a NeTEx 
 
 See [Table_AlternativeText.md](Table_AlternativeText.md) for detailed attribute specifications.
 
-Example XML: [AlternativeText.xml](AlternativeText.xml)
+Example XML: [AlternativeText.xml](Example_AlternativeText_ERP.xml)

--- a/Objects/Authority/Description_Authority.md
+++ b/Objects/Authority/Description_Authority.md
@@ -62,5 +62,5 @@ Authority
 
 For a complete list of all elements, attributes, cardinalities, and data types, see [Table — Authority](Table_Authority.md).
 
-Example XML: [Example_Authority.xml](Example_Authority.xml)
+Example XML: [Example_Authority.xml](Example_Authority_ERP.xml)
 

--- a/Objects/DatedServiceJourney/Description_DatedServiceJourney.md
+++ b/Objects/DatedServiceJourney/Description_DatedServiceJourney.md
@@ -33,7 +33,7 @@ A **DatedServiceJourney** represents a specific operational instance of a `Servi
 - [ServiceJourney](../ServiceJourney/Table_ServiceJourney.md) – The reusable template that this dated instance realizes
 - [OperatingDay](../OperatingDay/Table_OperatingDay.md) – The specific calendar day on which this journey operates
 - [TrainBlock](../TrainBlock/Table_TrainBlock.md) – Optional vehicle/block assignment for operational continuity
-- [DatedVehicleJourney](../DatedVehicleJourney/Table_DatedVehicleJourney.md) – Related journeys being reinforced or replaced
+- [DatedVehicleJourney](../DatedServiceJourney/Table_DatedServiceJourney.md) – Related journeys being reinforced or replaced
 
 ## 5. Usage Notes
 
@@ -72,7 +72,7 @@ For a complete list of all elements, attributes, cardinalities, and data types, 
 
 Minimal and scenario-specific XML examples are provided:
 
-1. **Minimal** – [Example_DatedServiceJourney.xml](Example_DatedServiceJourney.xml)
+1. **Minimal** – [Example_DatedServiceJourney.xml](Example_DatedServiceJourney_ERP.xml)
 2. **01 Reinforcement** – [Example_DatedServiceJourney_Extended_01_Reinforcement.xml](Example_DatedServiceJourney_Extended_01_Reinforcement.xml) – Additional vehicle/crew added to handle increased demand
 3. **02 Replacement** – [Example_DatedServiceJourney_Extended_02_Replacement.xml](Example_DatedServiceJourney_Extended_02_Replacement.xml) – Substitutes for cancelled or redirected journey
 4. **03 Block-Linked** – [Example_DatedServiceJourney_Extended_03_BlockLinked.xml](Example_DatedServiceJourney_Extended_03_BlockLinked.xml) – Journey linked via BlockRef for vehicle continuity

--- a/Objects/DatedServiceJourney/Table_DatedServiceJourney.md
+++ b/Objects/DatedServiceJourney/Table_DatedServiceJourney.md
@@ -23,5 +23,5 @@ DatedServiceJourney
 | [TrainBlock](../TrainBlock/Table_TrainBlock.md)/@ref | BlockRef | 0..1 | 0..1 | 0..1 | Reference to an operational Block/TrainBlock. | BlockRef/@ref |
 | ServiceAlteration | ServiceAlterationEnumeration | 0..1 | 0..1 | 0..1 | Deviation type. Allowed values: `planned` · `cancellation` · `replaced` · `extraJourney`. Omitted implies `planned`. | ServiceAlteration |
 | replacedJourneys | replacedJourneys | 0..1 |  | 0..1 | Container for references to journeys being replaced or reinforced. | replacedJourneys |
-| [DatedVehicleJourney](../DatedVehicleJourney/Table_DatedVehicleJourney.md)/@ref | DatedVehicleJourneyRef | 0..n |  | 0..n | References to journeys being replaced/reinforced. | replacedJourneys/DatedVehicleJourneyRef/@ref |
+| [DatedVehicleJourney](../DatedServiceJourney/Table_DatedServiceJourney.md)/@ref | DatedVehicleJourneyRef | 0..n |  | 0..n | References to journeys being replaced/reinforced. | replacedJourneys/DatedVehicleJourneyRef/@ref |
 

--- a/Objects/DayType/Description_DayType.md
+++ b/Objects/DayType/Description_DayType.md
@@ -52,4 +52,4 @@ A **DayType** represents a classification of days on which a specific set of tra
 
 See [Table_DayType.md](Table_DayType.md) for detailed attribute specifications.
 
-Example XML: [Example_DayType.xml](Example_DayType.xml)
+Example XML: [Example_DayType.xml](Example_DayType_ERP.xml)

--- a/Objects/DestinationDisplay/Description_DestinationDisplay.md
+++ b/Objects/DestinationDisplay/Description_DestinationDisplay.md
@@ -53,4 +53,4 @@ DestinationDisplay
 
 See [Table_DestinationDisplay.md](Table_DestinationDisplay.md) for detailed attribute specifications.
 
-Example XML: [DestinationDisplay.xml](DestinationDisplay.xml)
+Example XML: [DestinationDisplay.xml](Example_DestinationDisplay_ERP.xml)

--- a/Objects/FlexibleServiceProperties/Description_FlexibleServiceProperties.md
+++ b/Objects/FlexibleServiceProperties/Description_FlexibleServiceProperties.md
@@ -52,4 +52,4 @@ The **FlexibleServiceProperties** defines the scheduling and operational charact
 
 See [Table_FlexibleServiceProperties.md](Table_FlexibleServiceProperties.md) for detailed attribute specifications.
 
-Example XML: [FlexibleServiceProperties.xml](FlexibleServiceProperties.xml)
+Example XML: [FlexibleServiceProperties.xml](Example_FlexibleServiceProperties_ERP.xml)

--- a/Objects/Interchange/Description_Interchange.md
+++ b/Objects/Interchange/Description_Interchange.md
@@ -59,4 +59,4 @@ An **Interchange** (modelled as `ServiceJourneyInterchange` in XML) represents a
 
 See [Table_Interchange.md](Table_Interchange.md) for detailed attribute specifications.
 
-Example XML: [Example_Interchange.xml](Example_Interchange.xml)
+Example XML: [Example_Interchange.xml](Example_Interchange_ERP.xml)

--- a/Objects/JourneyPattern/Description_JourneyPattern.md
+++ b/Objects/JourneyPattern/Description_JourneyPattern.md
@@ -73,4 +73,4 @@ JourneyPattern
 
 See [Table_JourneyPattern.md](Table_JourneyPattern.md) for detailed attribute specifications.
 
-Example XML: [Example_JourneyPattern.xml](Example_JourneyPattern.xml)
+Example XML: [Example_JourneyPattern.xml](Example_JourneyPattern_ERP.xml)

--- a/Objects/Line/Description_Line.md
+++ b/Objects/Line/Description_Line.md
@@ -86,7 +86,7 @@ See [Table_Line.md](Table_Line.md) for detailed attribute specifications, cardin
 </Line>
 ```
 
-→ [Full file](Example_Line_MIN.xml)
+→ [Full file](Example_Line_ERP.xml)
 
 #### **NP (Nordic)**
 

--- a/Objects/Operator/Description_Operator.md
+++ b/Objects/Operator/Description_Operator.md
@@ -59,5 +59,5 @@ Operator
 > - **Duplicate Operators for same service**: Creating separate Operators for the same entity (e.g., one for commute services, one for leisure) breaks referential integrity. Use a single Operator with multiple Lines instead.
 
 ## 6. Additional Information
-See [Table_Operator.md](Table_Operator.md) for detailed attribute specifications and [Example_Operator.xml](Example_Operator.xml) for a complete XML instance based on the ERP profile.
+See [Table_Operator.md](Table_Operator.md) for detailed attribute specifications and [Example_Operator.xml](Example_Operator_ERP.xml) for a complete XML instance based on the ERP profile.
 

--- a/Objects/Parking/Description_Parking.md
+++ b/Objects/Parking/Description_Parking.md
@@ -69,4 +69,4 @@ Parking
 
 See [Table_Parking.md](Table_Parking.md) for detailed attribute specifications.
 
-Example XML: [Parking.xml](Parking.xml)
+Example XML: [Parking.xml](Example_Parking_ERP.xml)

--- a/Objects/PassengerStopAssignment/Description_PassengerStopAssignment.md
+++ b/Objects/PassengerStopAssignment/Description_PassengerStopAssignment.md
@@ -54,4 +54,4 @@ A **PassengerStopAssignment** links a logical ScheduledStopPoint to a physical Q
 
 See [Table_PassengerStopAssignment.md](Table_PassengerStopAssignment.md) for detailed attribute specifications.
 
-Example XML: [Example_PassengerStopAssignment.xml](Example_PassengerStopAssignment.xml)
+Example XML: [Example_PassengerStopAssignment.xml](Example_PassengerStopAssignment_ERP.xml)

--- a/Objects/PurposeOfGrouping/Description_PurposeOfGrouping.md
+++ b/Objects/PurposeOfGrouping/Description_PurposeOfGrouping.md
@@ -49,4 +49,4 @@ The **PurposeOfGrouping** classifies the reason why NeTEx objects are grouped to
 
 See [Table_PurposeOfGrouping.md](Table_PurposeOfGrouping.md) for detailed attribute specifications.
 
-Example XML: [PurposeOfGrouping.xml](PurposeOfGrouping.xml)
+Example XML: [PurposeOfGrouping.xml](Example_PurposeOfGrouping_ERP.xml)

--- a/Objects/Quay/Description_Quay.md
+++ b/Objects/Quay/Description_Quay.md
@@ -69,4 +69,4 @@ Quay
 > - **Coordinate precision loss**: Using too few decimal places (e.g., 59.91 instead of 59.9127) reduces accuracy for accessibility routing and vehicle docking; recommendation is 4–6 decimal places.
 
 ## 6. Additional Information
-See [Table_Quay.md](Table_Quay.md) for detailed property specifications and cardinality constraints. See [Example_Quay.xml](Example_Quay.xml) for a complete, validated XML instance embedded within a StopPlace container.
+See [Table_Quay.md](Table_Quay.md) for detailed property specifications and cardinality constraints. See [Example_Quay.xml](Example_Quay_ERP.xml) for a complete, validated XML instance embedded within a StopPlace container.

--- a/Objects/Route/Description_Route.md
+++ b/Objects/Route/Description_Route.md
@@ -61,4 +61,4 @@ The **Route** represents the logical geographic path definition for a Line with 
 > - **Multiple routes with identical stop sequences under one Line**: Unnecessarily creating separate Routes that differ only in DirectionType or naming; consolidate where possible and distinguish via DirectionType and PublicCode.
 
 ## 6. Additional Information
-See [Table_Route.md](Table_Route.md) for detailed attribute specifications, cardinality rules, and the complete PointsInSequence structure. See [Example_Route.xml](Example_Route.xml) for a complete, validated XML instance showing Route with ordered PointOnRoute elements.
+See [Table_Route.md](Table_Route.md) for detailed attribute specifications, cardinality rules, and the complete PointsInSequence structure. See [Example_Route.xml](Example_Route_ERP.xml) for a complete, validated XML instance showing Route with ordered PointOnRoute elements.

--- a/Objects/SanitaryEquipment/Description_SanitaryEquipment.md
+++ b/Objects/SanitaryEquipment/Description_SanitaryEquipment.md
@@ -52,4 +52,4 @@ The **SanitaryEquipment** describes sanitary facilities (toilets, washrooms) ava
 
 See [Table_SanitaryEquipment.md](Table_SanitaryEquipment.md) for detailed attribute specifications.
 
-Example XML: [SanitaryEquipment.xml](SanitaryEquipment.xml)
+Example XML: [SanitaryEquipment.xml](Example_SanitaryEquipment_ERP.xml)

--- a/Objects/ScheduledStopPoint/Description_ScheduledStopPoint.md
+++ b/Objects/ScheduledStopPoint/Description_ScheduledStopPoint.md
@@ -52,4 +52,4 @@ A **ScheduledStopPoint** represents a logical stopping point in the timetable, u
 
 See [Table_ScheduledStopPoint.md](Table_ScheduledStopPoint.md) for detailed attribute specifications.
 
-Example XML: [Example_ScheduledStopPoint.xml](Example_ScheduledStopPoint.xml)
+Example XML: [Example_ScheduledStopPoint.xml](Example_ScheduledStopPoint_ERP.xml)

--- a/Objects/ServiceJourney/Description_ServiceJourney.md
+++ b/Objects/ServiceJourney/Description_ServiceJourney.md
@@ -51,7 +51,7 @@ A **ServiceJourney** represents a planned trip in the timetable operating on a r
 - [Operator](../Operator/Table_Operator.md) – Identifies the service provider
 - [Line](../Line/Table_Line.md) – The public transport line being served
 - [DatedServiceJourney](../DatedServiceJourney/Description_DatedServiceJourney.md) – Per-date instances and alterations of this journey
-- [Block](../Block/Table_Block.md) – Optional vehicle/roster grouping
+- [Block](../TrainBlock/Table_TrainBlock.md) – Optional vehicle/roster grouping
 
 ## 5. Usage Notes
 
@@ -65,4 +65,4 @@ A **ServiceJourney** represents a planned trip in the timetable operating on a r
 
 For a complete list of all elements, attributes, cardinalities, and data types, see [Table — ServiceJourney](Table_ServiceJourney.md).
 
-Example XML: [Example_ServiceJourney.xml](Example_ServiceJourney.xml) and [Example_ServiceJourney_MIN.xml](Example_ServiceJourney_MIN.xml)
+Example XML: [Example_ServiceJourney.xml](Example_ServiceJourney_ERP.xml) and [Example_ServiceJourney_MIN.xml](Example_ServiceJourney_ERP.xml)

--- a/Objects/ServiceJourney/Table_ServiceJourney.md
+++ b/Objects/ServiceJourney/Table_ServiceJourney.md
@@ -50,10 +50,10 @@ ServiceJourney
 | RailSubmode | RailSubmodeEnumeration | 0..1 | 0..1 |  | Submode for rail services | TransportSubmode/RailSubmode |
 | [JourneyPatternRef](../JourneyPattern/Table_JourneyPattern.md)/@ref | VersionedRef | 0..1 | 1..1 | 1..1 | Reference to the JourneyPattern defining the stop sequence | JourneyPatternRef/@ref |
 | [LineRef](../Line/Table_Line.md)/@ref | VersionedRef | 0..1 | 0..1 | 0..1 | Reference to the served Line | LineRef/@ref |
-| [FlexibleLineRef](../FlexibleLine/Table_FlexibleLine.md)/@ref | VersionedRef | 0..1 | 0..1 |  | Reference to a FlexibleLine (on‑demand services) | FlexibleLineRef/@ref |
+| [FlexibleLineRef](../FlexibleServiceProperties/Table_FlexibleServiceProperties.md)/@ref | VersionedRef | 0..1 | 0..1 |  | Reference to a FlexibleLine (on‑demand services) | FlexibleLineRef/@ref |
 | [OperatorRef](../Operator/Table_Operator.md)/@ref | VersionedRef | 0..1 | 0..1 | 0..1 | Reference to an Operator | OperatorRef/@ref |
 | [DayTypeRef](../DayType/Table_DayType.md)/@ref | VersionedRef | 0..n | 0..n | 0..n | DayType(s) on which the journey operates | dayTypes/DayTypeRef/@ref |
-| [TimetabledPassingTime](../PassingTimes/Table_TimetabledPassingTime.md) | TimetabledPassingTime | 0..n | 1..n | 1..n | Collection of scheduled passing/stop times | passingTimes/TimetabledPassingTime |
+| [TimetabledPassingTime](../ServiceJourney/Table_ServiceJourney.md) | TimetabledPassingTime | 0..n | 1..n | 1..n | Collection of scheduled passing/stop times | passingTimes/TimetabledPassingTime |
 | TimetabledPassingTime/@id | xsd:ID | 0..1 | 0..1 | 0..1 | Optional identifier for the TimetabledPassingTime element | passingTimes/TimetabledPassingTime/@id |
 | [StopPointInJourneyPatternRef](../JourneyPattern/Table_JourneyPattern.md)/@ref | VersionedRef | 0..1 | 1..1 | 1..1 | Reference to a StopPointInJourneyPattern | passingTimes/TimetabledPassingTime/StopPointInJourneyPatternRef/@ref |
 | ArrivalTime | xsd:time | 0..1 | 0..1 | 0..1 | Planned arrival time at the stop | passingTimes/TimetabledPassingTime/ArrivalTime |
@@ -62,6 +62,6 @@ ServiceJourney
 | DepartureDayOffset | xsd:integer | 0..1 | 0..1 |  | Offset applied to DepartureTime | passingTimes/TimetabledPassingTime/DepartureDayOffset |
 | EarliestDepartureTime | xsd:time | 0..1 | 0..1 |  | Earliest allowed pick‑up time (flexible journeys) | passingTimes/TimetabledPassingTime/EarliestDepartureTime |
 | LatestArrivalTime | xsd:time | 0..1 | 0..1 |  | Latest allowed drop‑off time (flexible journeys) | passingTimes/TimetabledPassingTime/LatestArrivalTime |
-| [KeyValue](../KeyValue/Table_KeyValue.md) | KeyValue | 0..n | 0..n |  | Arbitrary key/value metadata on the journey | keyList/KeyValue |
-| [JourneyPart](../JourneyPart/Table_JourneyPart.md) | JourneyPart | 0..n | 0..n |  | Used for combined or split journeys | parts/JourneyPart |
+| [KeyValue](../ServiceJourney/Table_ServiceJourney.md) | KeyValue | 0..n | 0..n |  | Arbitrary key/value metadata on the journey | keyList/KeyValue |
+| [JourneyPart](../ServiceJourney/Table_ServiceJourney.md) | JourneyPart | 0..n | 0..n |  | Used for combined or split journeys | parts/JourneyPart |
 | BlockRef/@ref | VersionedRef | 0..1 | 0..1 |  | Reference to a Block or TrainBlock (vehicle working) | BlockRef/@ref |

--- a/Objects/ShelterEquipment/Description_ShelterEquipment.md
+++ b/Objects/ShelterEquipment/Description_ShelterEquipment.md
@@ -51,4 +51,4 @@ The **ShelterEquipment** describes weather shelter facilities available at a sto
 
 See [Table_ShelterEquipment.md](Table_ShelterEquipment.md) for detailed attribute specifications.
 
-Example XML: [ShelterEquipment.xml](ShelterEquipment.xml)
+Example XML: [ShelterEquipment.xml](Example_ShelterEquipment_ERP.xml)

--- a/Objects/StopPlace/Description_StopPlace.md
+++ b/Objects/StopPlace/Description_StopPlace.md
@@ -83,4 +83,4 @@ StopPlace (Multimodal Parent)
 > **Centroid positioning**: For monomodal stops, place the Centroid centrally between all serving Quays. For multimodal parents, position it at the hub center — not at a single Quay.
 
 ## 6. Additional Information
-See [Table_StopPlace.md](Table_StopPlace.md) for detailed attribute specifications, cardinality rules, and the complete element structure. See [Example_StopPlace.xml](Example_StopPlace.xml) for examples of monomodal and multimodal StopPlace configurations with embedded Quays.
+See [Table_StopPlace.md](Table_StopPlace.md) for detailed attribute specifications, cardinality rules, and the complete element structure. See [Example_StopPlace.xml](Example_StopPlace_ERP.xml) for examples of monomodal and multimodal StopPlace configurations with embedded Quays.

--- a/Objects/TariffZone/Description_TariffZone.md
+++ b/Objects/TariffZone/Description_TariffZone.md
@@ -55,4 +55,4 @@ TariffZone
 
 See [Table_TariffZone.md](Table_TariffZone.md) for detailed attribute specifications.
 
-Example XML: [TariffZone.xml](TariffZone.xml)
+Example XML: [TariffZone.xml](Example_TariffZone_ERP.xml)

--- a/Objects/TicketingEquipment/Description_TicketingEquipment.md
+++ b/Objects/TicketingEquipment/Description_TicketingEquipment.md
@@ -56,4 +56,4 @@ The **TicketingEquipment** describes ticket machines, validators, or other ticke
 
 See [Table_TicketingEquipment.md](Table_TicketingEquipment.md) for detailed attribute specifications.
 
-Example XML: [TicketingEquipment.xml](TicketingEquipment.xml)
+Example XML: [TicketingEquipment.xml](Example_TicketingEquipment_ERP.xml)

--- a/Objects/TopographicPlace/Description_TopographicPlace.md
+++ b/Objects/TopographicPlace/Description_TopographicPlace.md
@@ -60,4 +60,4 @@ TopographicPlace
 
 See [Table_TopographicPlace.md](Table_TopographicPlace.md) for detailed attribute specifications.
 
-Example XML: [TopographicPlace.xml](TopographicPlace.xml)
+Example XML: [TopographicPlace.xml](Example_TopographicPlace_ERP.xml)

--- a/Objects/WaitingRoomEquipment/Description_WaitingRoomEquipment.md
+++ b/Objects/WaitingRoomEquipment/Description_WaitingRoomEquipment.md
@@ -52,4 +52,4 @@ The **WaitingRoomEquipment** describes enclosed indoor waiting room facilities a
 
 See [Table_WaitingRoomEquipment.md](Table_WaitingRoomEquipment.md) for detailed attribute specifications.
 
-Example XML: [WaitingRoomEquipment.xml](WaitingRoomEquipment.xml)
+Example XML: [WaitingRoomEquipment.xml](Example_WaitingRoomEquipment_ERP.xml)


### PR DESCRIPTION
## Changes

- **Fix 63 broken markdown links** across 31 files:
  - 27 Object Description files — wrong/old example filenames → correct `_ERP.xml`
  - 4 Object cross-references — dead links to renamed objects
  - 50 TableOfExamples.md refs — `_MIN.xml` → `_ERP.xml`
  - 3 LLM/README.md paths — wrong relative depth
  - 2 Guide links — Interchange example + FramesOverview
- **Fix link checker config** — exclude Docsify absolute paths, sidebar, templates; set to warning-only mode